### PR TITLE
Expose registration failure event

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ And the following methods to support registration and receiving notifications:
   [RNNotifications didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+  [RNNotifications didFailToRegisterForRemoteNotificationsWithError:error];
+}
+
 // Required for the notification event.
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
   [RNNotifications didReceiveRemoteNotification:notification];
@@ -151,16 +155,29 @@ import NotificationsIOS from 'react-native-notifications';
 class App extends Component {
 	constructor() {
 		NotificationsIOS.addEventListener('remoteNotificationsRegistered', this.onPushRegistered.bind(this));
+		NotificationsIOS.addEventListener('remoteNotificationsRegistrationFailed', this.onPushRegistrationFaled.bind(this));
 		NotificationsIOS.requestPermissions();
 	}
 	
 	onPushRegistered(deviceToken) {
 		console.log("Device Token Received", deviceToken);
 	}
+
+	onPushRegistrationFailed(error) {
+		// For example:
+		//
+		// error={
+		//   domain: 'NSCocoaErroDomain',
+		//   code: 3010,
+		//   localizedDescription: 'remote notifications are not supported in the simulator'
+		// }
+		console.error(error);
+	}
 	
 	componentWillUnmount() {
   		// prevent memory leaks!
   		NotificationsIOS.removeEventListener('remoteNotificationsRegistered', this.onPushRegistered.bind(this));
+		NotificationsIOS.removeEventListener('remoteNotificationsRegistrationFailed', this.onPushRegistrationFailed.bind(this));
 	}
 }
 

--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -6,6 +6,7 @@
 @interface RNNotifications : NSObject <RCTBridgeModule>
 
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
++ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 + (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -12,6 +12,7 @@ NSString* const RNNotificationCreateAction = @"CREATE";
 NSString* const RNNotificationClearAction = @"CLEAR";
 
 NSString* const RNNotificationsRegistered = @"RNNotificationsRegistered";
+NSString* const RNNotificationsRegistrationFailed = @"RNNotificationsRegistrationFailed";
 NSString* const RNPushKitRegistered = @"RNPushKitRegistered";
 NSString* const RNNotificationReceivedForeground = @"RNNotificationReceivedForeground";
 NSString* const RNNotificationReceivedBackground = @"RNNotificationReceivedBackground";
@@ -119,6 +120,11 @@ RCT_EXPORT_MODULE()
                                                object:nil];
 
     [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleNotificationsRegistrationFailed:)
+                                                 name:RNNotificationsRegistrationFailed
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handlePushKitRegistered:)
                                                  name:RNPushKitRegistered
                                                object:nil];
@@ -162,6 +168,12 @@ RCT_EXPORT_MODULE()
     [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationsRegistered
                                                         object:self
                                                       userInfo:@{@"deviceToken": [self deviceTokenToString:deviceToken]}];
+}
+
++ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
+    [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationsRegistrationFailed
+                                                        object:self
+                                                      userInfo:@{@"code": [NSNumber numberWithInteger:error.code], @"domain": error.domain, @"localizedDescription": error.localizedDescription}];
 }
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification
@@ -387,6 +399,11 @@ RCT_EXPORT_MODULE()
 - (void)handleNotificationsRegistered:(NSNotification *)notification
 {
     [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationsRegistered" body:notification.userInfo];
+}
+
+- (void)handleNotificationsRegistrationFailed:(NSNotification *)notification
+{
+    [_bridge.eventDispatcher sendDeviceEventWithName:@"remoteNotificationsRegistrationFailed" body:notification.userInfo];
 }
 
 - (void)handlePushKitRegistered:(NSNotification *)notification

--- a/index.ios.js
+++ b/index.ios.js
@@ -10,6 +10,7 @@ const NativeRNNotifications = NativeModules.RNNotifications; // eslint-disable-l
 import IOSNotification from "./notification.ios";
 
 export const DEVICE_REMOTE_NOTIFICATIONS_REGISTERED_EVENT = "remoteNotificationsRegistered";
+export const DEVICE_REMOTE_NOTIFICATIONS_REGISTRATION_FAILED_EVENT = "remoteNotificationsRegistrationFailed";
 export const DEVICE_PUSH_KIT_REGISTERED_EVENT = "pushKitRegistered";
 export const DEVICE_NOTIFICATION_RECEIVED_FOREGROUND_EVENT = "notificationReceivedForeground";
 export const DEVICE_NOTIFICATION_RECEIVED_BACKGROUND_EVENT = "notificationReceivedBackground";
@@ -19,6 +20,7 @@ const DEVICE_NOTIFICATION_ACTION_RECEIVED = "notificationActionReceived";
 
 const _exportedEvents = [
   DEVICE_REMOTE_NOTIFICATIONS_REGISTERED_EVENT,
+  DEVICE_REMOTE_NOTIFICATIONS_REGISTRATION_FAILED_EVENT,
   DEVICE_PUSH_KIT_REGISTERED_EVENT,
   DEVICE_NOTIFICATION_RECEIVED_FOREGROUND_EVENT,
   DEVICE_NOTIFICATION_RECEIVED_BACKGROUND_EVENT,
@@ -61,6 +63,11 @@ export default class NotificationsIOS {
         listener = DeviceEventEmitter.addListener(
           DEVICE_REMOTE_NOTIFICATIONS_REGISTERED_EVENT,
           registration => handler(registration.deviceToken)
+        );
+      } else if (type === DEVICE_REMOTE_NOTIFICATIONS_REGISTRATION_FAILED_EVENT) {
+        listener = DeviceEventEmitter.addListener(
+          DEVICE_REMOTE_NOTIFICATIONS_REGISTRATION_FAILED_EVENT,
+          error => handler(error)
         );
       } else if (type === DEVICE_PUSH_KIT_REGISTERED_EVENT) {
         listener = DeviceEventEmitter.addListener(

--- a/test/index.ios.spec.js
+++ b/test/index.ios.spec.js
@@ -9,6 +9,7 @@ describe("NotificationsIOS", () => {
   let deviceEvents = [
     "pushKitRegistered",
     "remoteNotificationsRegistered",
+    "remoteNotificationsRegistrationFailed",
     "notificationReceivedForeground",
     "notificationReceivedBackground",
     "notificationOpened"


### PR DESCRIPTION
With the current implementation there is no way of telling whether or not the push registration was successful. This PR exposes the native `didFailToRegisterForRemoteNotificationsWithError` to JS by means of a newly introduced `remoteNotificationsRegistrationFailed` event. This allows for gracefully handling failure cases.