### PR TITLE
Add fetchCompletionHandler

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,15 @@ And the following methods to support registration and receiving notifications:
   [RNNotifications didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-// Required for the notification event.
+// Deprecated
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
   [RNNotifications didReceiveRemoteNotification:notification];
+}
+
+// Required for the notification event.
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
+                                                       fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler {
+  [RNNotifications didReceiveRemoteNotification:notification fetchCompletionHandler:completionHandler];
 }
 
 // Required for the localNotification event.
@@ -229,6 +235,9 @@ onNotificationReceivedForeground(notification) {
 
 onNotificationReceivedBackground(notification) {
 	console.log("Notification Received - Background", notification);
+  // You must call this method for all background notifications to tell the OS
+  // you are done processing and its safe to shutdown the app.
+  notification.finish(NotificationsIOS.RemoteBackgroundFetchResult.NewData);
 }
 
 onNotificationOpened(notification) {

--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -5,12 +5,15 @@
 
 @interface RNNotifications : NSObject <RCTBridgeModule>
 
+typedef void (^RCTRemoteNotificationCallback)(UIBackgroundFetchResult result);
+
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 + (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
++ (void)didReceiveRemoteNotification:(NSDictionary *)notification fetchCompletionHandler:(RCTRemoteNotificationCallback)completionHandler;
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification;
 
 + (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;

--- a/index.ios.js
+++ b/index.ios.js
@@ -44,6 +44,13 @@ export class NotificationCategory {
 }
 
 export default class NotificationsIOS {
+
+  static RemoteBackgroundFetchResult = {
+    NewData: 'UIBackgroundFetchResultNewData',
+    NoData: 'UIBackgroundFetchResultNoData',
+    ResultFailed: 'UIBackgroundFetchResultFailed',
+  };
+
   /**
    * Attaches a listener to remote notification events while the app is running
    * in the foreground or the background.

--- a/index.ios.js
+++ b/index.ios.js
@@ -46,9 +46,9 @@ export class NotificationCategory {
 export default class NotificationsIOS {
 
   static RemoteBackgroundFetchResult = {
-    NewData: 'UIBackgroundFetchResultNewData',
-    NoData: 'UIBackgroundFetchResultNoData',
-    ResultFailed: 'UIBackgroundFetchResultFailed',
+    NewData: "UIBackgroundFetchResultNewData",
+    NoData: "UIBackgroundFetchResultNoData",
+    ResultFailed: "UIBackgroundFetchResultFailed"
   };
 
   /**

--- a/notification.ios.js
+++ b/notification.ios.js
@@ -33,9 +33,10 @@ export default class IOSNotification {
       this._sound = notification.aps.sound;
       this._badge = notification.aps.badge;
       this._category = notification.aps.category;
-      this._id = notification.__id;
       this._type = "regular";
     }
+
+    this._id = notification.__id;
 
     Object.keys(notification).filter(key => key !== "aps").forEach(key => {
       this._data[key] = notification[key];

--- a/notification.ios.js
+++ b/notification.ios.js
@@ -1,4 +1,8 @@
+import { NativeModules } from "react-native";
+const NativeRNNotifications = NativeModules.RNNotifications; // eslint-disable-line no-unused-vars
+
 export default class IOSNotification {
+  _id: string;
   _data: Object;
   _alert: string | Object;
   _sound: string;
@@ -29,12 +33,19 @@ export default class IOSNotification {
       this._sound = notification.aps.sound;
       this._badge = notification.aps.badge;
       this._category = notification.aps.category;
+      this._id = notification.__id;
       this._type = "regular";
     }
 
     Object.keys(notification).filter(key => key !== "aps").forEach(key => {
       this._data[key] = notification[key];
     });
+  }
+
+  finish(fetchResult) {
+    if (this._id) {
+      NativeRNNotifications.onFinishRemoteNotification(this._id, fetchResult);
+    }
   }
 
   getMessage(): ?string | ?Object {


### PR DESCRIPTION
This adds a `didReceiveNotificationOnBackgroundState:fetchCompletionHandler` method. Which you can call like so:
```objectivec
- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
                                                       fetchCompletionHandler:(nonnull void (^)(UIBackgroundFetchResult))completionHandler {
  [RNNotifications didReceiveRemoteNotification:notification fetchCompletionHandler:completionHandler];
}
```
[Docs on this method:](https://developer.apple.com/reference/uikit/uiapplicationdelegate/1623013-application?language=objc) 
> Use this method to process incoming remote notifications for your app. Unlike the application:didReceiveRemoteNotification: method, which is called only when your app is running in the foreground, the system calls this method when your app is running in the foreground or background. In addition, if you enabled the remote notifications background mode, the system launches your app (or wakes it from the suspended state) and puts it in the background state when a remote notification arrives. **However, the system does not automatically launch your app if the user has force-quit it**. In that situation, the user must relaunch your app or restart the device before the system attempts to launch your app automatically again.



Let me know how I can clean up this PR to your liking :)

Fixes: https://github.com/wix/react-native-notifications/issues/9
