### PR TITLE
Various Enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,6 +373,26 @@ NotificationsIOS.cancelAllLocalNotifications();
 
 ---
 
+## Badge Counts
+
+Setting a badge is possible on iOS and Android. In addition to this retreiving the badge is possible on iOS but _not_ yet supported on Android.
+
+To add `getBadgeCount` support on Android or to read up on what particular devices are supported [check here](https://github.com/leolin310148/ShortcutBadger).
+
+### iOS
+```js
+NotificationsIOS.setBadgeCount(10);
+NotificationsIOS.getBadgeCount(function(count) {
+  console.log('Badge count is', count); // 10
+});
+```
+
+### Android
+```js
+NotificationsAndroid.setBadgeCount(10);
+```
+
+
 ## Managed Notifications (iOS only)
 
 Managed notifications are notifications that can be cleared by a server request.

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -434,6 +434,17 @@ RCT_EXPORT_MODULE()
 /*
  * React Native exported methods
  */
+RCT_EXPORT_METHOD(setBadgeCount:(NSInteger *)count)
+{
+  [[UIApplication sharedApplication] setApplicationIconBadgeNumber:count];
+}
+
+RCT_EXPORT_METHOD(getBadgeCount:(RCTResponseSenderBlock)callback)
+{
+  NSNumber *count = [NSNumber numberWithInt:[[UIApplication sharedApplication] applicationIconBadgeNumber]];
+  callback(@[[NSNull null], count]);
+}
+
 RCT_EXPORT_METHOD(requestPermissionsWithCategories:(NSArray *)json)
 {
     NSMutableSet* categories = nil;

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,6 +24,8 @@ dependencies {
 
     compile 'com.facebook.react:react-native:+'
 
+    compile 'me.leolin:ShortcutBadger:1.1.8@aar'
+
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:2.+'
     testCompile 'org.robolectric:robolectric:3.1.4'

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -16,13 +16,14 @@ import com.facebook.react.bridge.ReadableMap;
 import com.wix.reactnativenotifications.core.AppLifecycleFacade;
 import com.wix.reactnativenotifications.core.AppLifecycleFacadeHolder;
 import com.wix.reactnativenotifications.core.InitialNotificationHolder;
-import com.wix.reactnativenotifications.core.ReactAppLifecycleFacade;
 import com.wix.reactnativenotifications.core.notification.IPushNotification;
 import com.wix.reactnativenotifications.core.notification.PushNotification;
 import com.wix.reactnativenotifications.core.notification.PushNotificationProps;
 import com.wix.reactnativenotifications.core.notificationdrawer.IPushNotificationsDrawer;
 import com.wix.reactnativenotifications.core.notificationdrawer.PushNotificationsDrawer;
+import com.wix.reactnativenotifications.core.ReactAppLifecycleFacade;
 import com.wix.reactnativenotifications.gcm.GcmInstanceIdRefreshHandlerService;
+import com.wix.reactnativenotifications.helpers.ApplicationBadgeHelper;
 
 import static com.wix.reactnativenotifications.Defs.LOGTAG;
 
@@ -56,6 +57,11 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     public void refreshToken() {
         Log.d(LOGTAG, "Native method invocation: refreshToken()");
         startGcmIntentService(GcmInstanceIdRefreshHandlerService.EXTRA_MANUAL_REFRESH);
+    }
+
+    @ReactMethod
+    public void setBadgeCount(int bagdeCount) {
+        ApplicationBadgeHelper.INSTANCE.setApplicationIconBadgeNumber(getReactApplicationContext().getApplicationContext(), bagdeCount);
     }
 
     @ReactMethod

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -67,7 +67,9 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public void onReceived() throws InvalidNotificationException {
-        postNotification(null);
+        if (!mAppLifecycleFacade.isAppVisible()) {
+            postNotification(null);
+        }
         notifyReceivedToJS();
     }
 

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -67,7 +67,7 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public void onReceived() throws InvalidNotificationException {
-        if (!mAppLifecycleFacade.isAppVisible()) {
+        if (!mAppLifecycleFacade.isAppVisible() && mNotificationProps.isVisible()) {
             postNotification(null);
         }
         notifyReceivedToJS();

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -10,15 +10,24 @@ public class PushNotificationProps {
         mBundle = new Bundle();
     }
 
-    public PushNotificationProps(String title, String body) {
+    public PushNotificationProps(String title, String body, String sound, String group, int badge) {
         mBundle = new Bundle();
         mBundle.putString("title", title);
         mBundle.putString("body", body);
+        mBundle.putString("sound", sound);
+        mBundle.putString("group", group);
+        mBundle.putInt("badge", badge);
     }
 
     public PushNotificationProps(Bundle bundle) {
         mBundle = bundle;
     }
+
+    public int getBadge() { return mBundle.getInt("badge"); }
+
+    public String getGroup() { return mBundle.getString("group"); }
+
+    public String getSound() { return mBundle.getString("sound"); }
 
     public String getTitle() {
         return mBundle.getString("title");

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -23,18 +23,31 @@ public class PushNotificationProps {
         mBundle = bundle;
     }
 
-    public int getBadge() { return mBundle.getInt("badge"); }
+    public int getBadge() {
+        if (mBundle.containsKey("badge")) {
+            return mBundle.getInt("badge");
+        }
+        return -1;
+    }
 
     public String getGroup() { return mBundle.getString("group"); }
 
     public String getSound() { return mBundle.getString("sound"); }
 
-    public String getTitle() {
-        return mBundle.getString("title");
-    }
+    public String getTitle() { return mBundle.getString("title"); }
 
     public String getBody() {
         return mBundle.getString("body");
+    }
+
+    public boolean isVisible() {
+        String title = getTitle();
+        String sound = getSound();
+        String body = getBody();
+        return  getBadge() >= 0 ||
+                (title != null && !title.isEmpty()) ||
+                (sound != null && !sound.isEmpty()) ||
+                (body != null && !body.isEmpty());
     }
 
     public Bundle asBundle() {

--- a/android/src/main/java/com/wix/reactnativenotifications/helpers/ApplicationBadgeHelper.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/helpers/ApplicationBadgeHelper.java
@@ -1,0 +1,113 @@
+package com.wix.reactnativenotifications.helpers;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+
+import com.facebook.common.logging.FLog;
+
+import me.leolin.shortcutbadger.Badger;
+import me.leolin.shortcutbadger.ShortcutBadger;
+import me.leolin.shortcutbadger.impl.SamsungHomeBadger;
+
+/**
+ * Helper for setting application launcher icon badge counts.
+ * <p>
+ * This is a wrapper around {@link ShortcutBadger}, with a couple enhancements:
+ * <p>
+ * - If the first attempt fails, don't retry. This keeps logs clean, as failed attempts are noisy.
+ * - Test and apply a separate method for older Samsung devices, which ShortcutBadger has
+ * (perhaps over-aggressively) deprecated. ref: https://github.com/leolin310148/ShortcutBadger/issues/40
+ */
+public class ApplicationBadgeHelper {
+
+    public static final ApplicationBadgeHelper INSTANCE = new ApplicationBadgeHelper();
+
+    private static final String LOG_TAG = "ApplicationBadgeHelper";
+    private static final Badger LEGACY_SAMSUNG_BADGER = new SamsungHomeBadger();
+
+    private Boolean applyAutomaticBadger;
+    private Boolean applySamsungBadger;
+    private ComponentName componentName;
+    private boolean triedComponentName;
+
+    private ApplicationBadgeHelper() {
+    }
+
+    public void setApplicationIconBadgeNumber(Context context, int number) {
+        if (null == componentName && !triedComponentName) {
+            triedComponentName = true;
+            componentName = tryComponentName(context);
+        }
+        tryAutomaticBadge(context, number);
+        tryLegacySamsungBadge(context, number);
+    }
+
+    private ComponentName tryComponentName(Context context) {
+        try {
+            return context.getPackageManager().getLaunchIntentForPackage(context.getPackageName()).getComponent();
+        } catch (Exception e) {
+            FLog.w(LOG_TAG, "Failed to resolve component name; cannot attempt Samsung badge.", e);
+            return null;
+        }
+    }
+
+    private void tryAutomaticBadge(Context context, int number) {
+        if (null == applyAutomaticBadger) {
+            applyAutomaticBadger = ShortcutBadger.applyCount(context, number);
+            if (applyAutomaticBadger) {
+                FLog.i(LOG_TAG, "First attempt to use automatic badger succeeded; permanently enabling method.");
+            } else {
+                FLog.i(LOG_TAG, "First attempt to use automatic badger failed; permanently disabling method.");
+            }
+            return;
+        } else if (!applyAutomaticBadger) {
+            return;
+        }
+        ShortcutBadger.applyCount(context, number);
+    }
+
+    private void tryLegacySamsungBadge(Context context, int number) {
+        // First attempt to apply legacy samsung badge. Check if eligible, then attempt it.
+        if (null == applySamsungBadger) {
+            applySamsungBadger = isLegacySamsungLauncher(context) && applyLegacySamsungBadge(context, number);
+            if (applySamsungBadger) {
+                FLog.i(LOG_TAG, "First attempt to use legacy Samsung badger succeeded; permanently enabling method.");
+            } else {
+                FLog.w(LOG_TAG, "First attempt to use legacy Samsung badger failed; permanently disabling method.");
+            }
+            return;
+        } else if (!applySamsungBadger) {
+            return;
+        }
+        applyLegacySamsungBadge(context, number);
+    }
+
+    private boolean isLegacySamsungLauncher(Context context) {
+        Intent intent = new Intent(Intent.ACTION_MAIN);
+        intent.addCategory(Intent.CATEGORY_HOME);
+        ResolveInfo resolveInfo = context.getPackageManager().resolveActivity(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        if (resolveInfo == null || resolveInfo.activityInfo.name.toLowerCase().contains("resolver")) {
+            return false;
+        }
+
+        String currentHomePackage = resolveInfo.activityInfo.packageName;
+        return LEGACY_SAMSUNG_BADGER.getSupportLaunchers().contains(currentHomePackage);
+    }
+    
+    private boolean applyLegacySamsungBadge(Context context, int number) {
+        if (componentName == null) {
+            return false;
+        }
+        try {
+            LEGACY_SAMSUNG_BADGER.executeBadge(context, componentName, number);
+            return true;
+        } catch (Exception e) {
+            FLog.w(LOG_TAG, "Legacy Samsung badger failed", e);
+            return false;
+        }
+    }
+}

--- a/index.android.js
+++ b/index.android.js
@@ -45,6 +45,10 @@ export class NotificationsAndroid {
     RNNotifications.refreshToken();
   }
 
+  static setBadgeCount(number: Number) {
+    RNNotifications.setBadgeCount(number);
+  }
+
   static localNotification(notification: Object) {
     const id = Math.random() * 100000000 | 0; // Bitwise-OR forces value onto a 32bit limit
     RNNotifications.postLocalNotification(notification, id);

--- a/index.ios.js
+++ b/index.ios.js
@@ -192,6 +192,14 @@ export default class NotificationsIOS {
     return notificationId;
   }
 
+  static setBadgeCount(number: Number) {
+    NativeRNNotifications.setBadgeCount(number);
+  }
+
+  static getBadgeCount(callback: Function) {
+    NativeRNNotifications.getBadgeCount(callback);
+  }
+
   static cancelLocalNotification(notificationId: String) {
     NativeRNNotifications.cancelLocalNotification(notificationId);
   }


### PR DESCRIPTION
Some enhancements:
- Android notification sound (from server, using `sound` key)
- Android support for smallIcon, largeIcon in notification center
- Android notification title fallback to app name
- Android notification grouping (using the `group` key from server)
- Android set badge from notification (using `badge` key form server)
- Android HUD support (fixes https://github.com/wix/react-native-notifications/issues/20)
- Android don't put notification in notification center when app is visible AND the notification is not visual (i.e. notifications need sound, badge, title or body to be visual) -- this mimics the iOS behavior. Additionally I found that even if you create a notification that doesnt have sound, badge, title or body it still added a notification to notification center on some android devices (Galaxy S3)
- Android setBadgeCount (Using https://github.com/leolin310148/ShortcutBadger)
- iOS getBadgeCount
- iOS setBadgeCount

I understand this is a large PR, I apologize! I also am unfamiliar with your coding practices so hopefully we can work together to make any changes necessary :) Thanks!