### PR TITLE
Accept string device tokens

### DIFF
--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -9,7 +9,7 @@
 
 @interface RNNotifications : NSObject <RCTBridgeModule>
 
-+ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken;
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 + (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -171,11 +171,12 @@ RCT_EXPORT_MODULE()
     }
 }
 
-+ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken
 {
+    NSString *tokenRepresentation = [deviceToken isKindOfClass:[NSString class]] ? deviceToken : [self deviceTokenToString:deviceToken];
     [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationsRegistered
                                                         object:self
-                                                      userInfo:@{@"deviceToken": [self deviceTokenToString:deviceToken]}];
+                                                      userInfo:@{@"deviceToken": tokenRepresentation}];
 }
 
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {


### PR DESCRIPTION
This allows users to integrate with services that don't use Apple's APN ID as their primary device identifier, namely Firebase Cloud Messaging. With this change it's possible to consistently utilise FCM for both iOS and Android.