### PR TITLE
Fix regular notification + tests

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -26,7 +26,7 @@ public class RNNotificationsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext));
     }
 
-    @Override
+    // RN 0.47 compatibility
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/notification.ios.js
+++ b/notification.ios.js
@@ -21,9 +21,7 @@ export default class IOSNotification {
       this._badge = notification.aps.badge;
       this._category = notification.managedAps.category;
       this._type = "managed";
-    } else if (
-      notification.aps &&
-      notification.aps.alert) {
+    } else if (notification.aps) {
       // regular notification
       this._alert = notification.aps.alert;
       this._sound = notification.aps.sound;

--- a/test/notification.ios.spec.js
+++ b/test/notification.ios.spec.js
@@ -3,7 +3,6 @@ import { expect } from "chai";
 import IOSNotification from "../notification.ios";
 
 describe("iOS Notification Object", () => {
-  let notification;
   let someBadgeCount = 123, someSound = "someSound", someCategory = "some_notification_category";
 
   describe("for a regular iOS push notification", () => {
@@ -37,10 +36,20 @@ describe("iOS Notification Object", () => {
         },
         key1: "value1",
         key2: "value2"
+      },
+
+      // another example, with badge only
+      {
+        aps: {
+          badge: someBadgeCount
+        }
       }
     ];
 
     regularNativeNotifications.forEach(nativeNotification => {
+      let notification;
+      let {aps, ...data} = nativeNotification;
+
       beforeEach(() => {
         notification = new IOSNotification(nativeNotification);
       });
@@ -50,28 +59,29 @@ describe("iOS Notification Object", () => {
       });
 
       it("should return the alert object", () => {
-        expect(notification.getMessage()).to.deep.equal(nativeNotification.aps.alert);
+        expect(notification.getMessage()).to.deep.equal(aps.alert);
       });
 
       it("should return the sound", () => {
-        expect(notification.getSound()).to.equal(someSound);
+        expect(notification.getSound()).to.equal(aps.sound);
       });
 
       it("should return the badge count", () => {
-        expect(notification.getBadgeCount()).to.equal(someBadgeCount);
+        expect(notification.getBadgeCount()).to.equal(aps.badge);
       });
 
       it("should return the category", () => {
-        expect(notification.getCategory()).to.equal(someCategory);
+        expect(notification.getCategory()).to.equal(aps.category);
       });
 
       it("should return the custom data", () => {
-        expect(notification.getData()).to.deep.equal({ key1: "value1", key2: "value2" });
+        expect(notification.getData()).to.deep.equal(data);
       });
     });
   });
 
   describe("for a managed iOS push notification (silent notification, with managedAps key and content-available = 1)", () => {
+    let notification;
     let managedNativeNotification = {
       aps: {
         "content-available": 1,


### PR DESCRIPTION
When `aps` payload doesn't contain an `alert` key, the notification do not copy badge value and getBadgeCount() returns undefined.