### PR TITLE
Add iOS remote notification completion handler

### DIFF
--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -15,6 +15,7 @@
 + (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
++ (void)didReceiveRemoteNotification:(NSDictionary *)notification fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification;
 
 + (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -107,6 +107,10 @@ RCT_ENUM_CONVERTER(UIUserNotificationActionBehavior, (@{
 }
 @end
 
+@interface RNNotifications ()
+@property (nonatomic, strong) NSMutableDictionary *notificationCallbacks;
+@end
+
 @implementation RNNotifications
 
 RCT_EXPORT_MODULE()
@@ -186,6 +190,22 @@ RCT_EXPORT_MODULE()
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification
 {
+    [self didReceiveRemoteNotification:notification fetchCompletionHandler:nil];
+}
+
++ (void)didReceiveRemoteNotification:(NSDictionary *)notification
+    fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+    NSDictionary* data = notification;
+    if (completionHandler != nil) {
+        NSMutableDictionary* copy = [[NSMutableDictionary alloc] initWithDictionary: data];
+        NSString *completionHandlerId = [[NSUUID UUID] UUIDString];
+        copy[@"_completionHandlerId"] = completionHandlerId;
+        data = copy;
+        [[RNNotificationsBridgeQueue sharedInstance] postFetchHandler:data completionKey:completionHandlerId
+            fetchCompletionHandler:completionHandler];
+    }
+    
     UIApplicationState state = [UIApplication sharedApplication].applicationState;
 
     if ([RNNotificationsBridgeQueue sharedInstance].jsIsReady == YES) {
@@ -193,17 +213,17 @@ RCT_EXPORT_MODULE()
 
         if (state == UIApplicationStateActive) {
             // Notification received foreground
-            [self didReceiveNotificationOnForegroundState:notification];
+            [self didReceiveNotificationOnForegroundState:data];
         } else if (state == UIApplicationStateInactive) {
             // Notification opened
-            [self didNotificationOpen:notification];
+            [self didNotificationOpen:data];
         } else {
             // Notification received background
-            [self didReceiveNotificationOnBackgroundState:notification];
+            [self didReceiveNotificationOnBackgroundState:data];
         }
     } else {
         // JS thread is not ready - store it in the native notifications queue
-        [[RNNotificationsBridgeQueue sharedInstance] postNotification:notification];
+        [[RNNotificationsBridgeQueue sharedInstance] postNotification:data];
     }
 }
 
@@ -464,6 +484,17 @@ RCT_EXPORT_METHOD(log:(NSString *)message)
 RCT_EXPORT_METHOD(completionHandler:(NSString *)completionKey)
 {
     [[RNNotificationsBridgeQueue sharedInstance] completeAction:completionKey];
+}
+
+RCT_EXPORT_METHOD(finishRemoteNotification:(NSString *)completionKey fetchResult:(NSString*) result)
+{
+    UIBackgroundFetchResult bgResult = UIBackgroundFetchResultNoData;
+    if ([@"NewData" isEqualToString:result]) {
+        bgResult = UIBackgroundFetchResultNewData;
+    } else if ([@"Failed" isEqualToString:result]) {
+        bgResult = UIBackgroundFetchResultFailed;
+    }
+    [[RNNotificationsBridgeQueue sharedInstance] completeFetch:completionKey fetchResult:bgResult];
 }
 
 RCT_EXPORT_METHOD(abandonPermissions)

--- a/RNNotifications/RNNotificationsBridgeQueue.h
+++ b/RNNotifications/RNNotificationsBridgeQueue.h
@@ -10,10 +10,13 @@
 
 - (void)postAction:(NSDictionary *)action withCompletionKey:(NSString *)completionKey andCompletionHandler:(void (^)())completionHandler;
 - (void)postNotification:(NSDictionary *)notification;
+- (void)postFetchHandler:(NSDictionary *)notification completionKey:(NSString *)completionKey
+    fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler;
 
 - (void)consumeActionsQueue:(void (^)(NSDictionary *))block;
 - (void)consumeNotificationsQueue:(void (^)(NSDictionary *))block;
 
 - (void)completeAction:(NSString *)completionKey;
+- (void)completeFetch:(NSString *)completionKey fetchResult:(UIBackgroundFetchResult)result;
 
 @end

--- a/index.ios.js
+++ b/index.ios.js
@@ -77,7 +77,11 @@ export default class NotificationsIOS {
       } else {
         listener = DeviceEventEmitter.addListener(
           type,
-          notification => handler(new IOSNotification(notification))
+          async (notification) => {
+            const iosNotification = new IOSNotification(notification);
+            await handler(iosNotification);
+            iosNotification.finish();
+          }
         );
       }
 

--- a/notification.ios.js
+++ b/notification.ios.js
@@ -72,7 +72,7 @@ export default class IOSNotification {
       this._finishCalled = true;
       const result = finishResult || REMOTE_NOTIFICATION_RESULT.NoData;
       if (!Object.values(REMOTE_NOTIFICATION_RESULT).includes(result)) {
-        throw new Error('Invalid REMOTE_NOTIFICATION_RESULT value');
+        throw new Error("Invalid REMOTE_NOTIFICATION_RESULT value");
       }
       RNNotifications.finishRemoteNotification(this._data._completionHandlerId, result);
     }
@@ -80,7 +80,7 @@ export default class IOSNotification {
 }
 
 export const REMOTE_NOTIFICATION_RESULT = {
-  NewData: 'NewData',
-  NoData: 'NoData',
-  Failed: 'Failed',
+  NewData: "NewData",
+  NoData: "NoData",
+  Failed: "Failed"
 };

--- a/notification.ios.js
+++ b/notification.ios.js
@@ -1,3 +1,7 @@
+"use strict";
+import { NativeModules } from "react-native";
+const RNNotifications = NativeModules.RNNotifications;
+
 export default class IOSNotification {
   _data: Object;
   _alert: string | Object;
@@ -5,6 +9,7 @@ export default class IOSNotification {
   _badge: number;
   _category: string;
   _type: string; // regular / managed
+  _finishCalled: boolean;
 
   constructor(notification: Object) {
     this._data = {};
@@ -35,6 +40,7 @@ export default class IOSNotification {
     Object.keys(notification).filter(key => key !== "aps").forEach(key => {
       this._data[key] = notification[key];
     });
+    this._finishCalled = false;
   }
 
   getMessage(): ?string | ?Object {
@@ -60,4 +66,21 @@ export default class IOSNotification {
   getType(): ?string {
     return this._type;
   }
+
+  finish(finishResult) {
+    if (!this._finishCalled && this._data._completionHandlerId) {
+      this._finishCalled = true;
+      const result = finishResult || REMOTE_NOTIFICATION_RESULT.NoData;
+      if (!Object.values(REMOTE_NOTIFICATION_RESULT).includes(result)) {
+        throw new Error('Invalid REMOTE_NOTIFICATION_RESULT value');
+      }
+      RNNotifications.finishRemoteNotification(this._data._completionHandlerId, result);
+    }
+  }
 }
+
+export const REMOTE_NOTIFICATION_RESULT = {
+  NewData: 'NewData',
+  NoData: 'NoData',
+  Failed: 'Failed',
+};

--- a/test/index.ios.spec.js
+++ b/test/index.ios.spec.js
@@ -83,6 +83,11 @@ describe("NotificationsIOS", () => {
           }
         },
         "@noCallThru": true
+      },
+      "./notification.ios": {
+        IOSNotification: {
+        },
+        "@noCallThru": true
       }
     });
 

--- a/test/notification.ios.spec.js
+++ b/test/notification.ios.spec.js
@@ -1,8 +1,28 @@
 "use strict";
 import { expect } from "chai";
-import IOSNotification from "../notification.ios";
+import proxyquire from "proxyquire";
 
 describe("iOS Notification Object", () => {
+  let IOSNotification;
+
+  before(() => {
+    let libUnderTest = proxyquire("../notification.ios", {
+      "react-native": {
+        NativeModules: {
+          RNNotifications: {
+          }
+        },
+        "@noCallThru": true
+      }
+    });
+
+    IOSNotification = libUnderTest.default;
+  });
+
+  after(() => {
+    IOSNotification = null;
+  });
+
   let notification;
   let someBadgeCount = 123, someSound = "someSound", someCategory = "some_notification_category";
 


### PR DESCRIPTION
Resolves #9.

This is needed for iOS silent push notifications while the app is in the background with the UIBackgroundModes remote-notification capability.  Without this enhancement, when the `didReceiveRemoteNotification` function finishes, the app will go back to sleep without finishing to process the javascript events.