### PR TITLE
Adds push type to iOS notification

### DIFF
--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -16,6 +16,7 @@
 
 + (void)didReceiveRemoteNotification:(NSDictionary *)notification;
 + (void)didReceiveLocalNotification:(UILocalNotification *)notification;
++ (void)didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type;
 
 + (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;
 + (void)handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -226,6 +226,13 @@ RCT_EXPORT_MODULE()
     }
 }
 
++ (void)didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(PKPushType)type
+{
+    NSMutableDictionary *dictionary = [payload.dictionaryPayload mutableCopy];
+    dictionary[@"_pushType"] = type;
+    [RNNotifications didReceiveRemoteNotification:dictionary];
+}
+
 + (void)handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
 {
     [self emitNotificationActionForIdentifier:identifier responseInfo:responseInfo userInfo:notification.userInfo completionHandler:completionHandler];

--- a/notification.ios.js
+++ b/notification.ios.js
@@ -60,4 +60,8 @@ export default class IOSNotification {
   getType(): ?string {
     return this._type;
   }
+
+  getPushType(): ?string {
+    return this._data._pushType;
+  }
 }


### PR DESCRIPTION
Resolves #89.

Adds the means from javascript to identify the pushkit notifications push type via
`notification.getPushType();`