### PR TITLE
Add iOS checkPermissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,16 @@ class App extends Component {
 
 When you have the device token, POST it to your server and register the device in your notifications provider (Amazon SNS, Azure, etc.).
 
+You can check if the user granted permissions by calling `checkPermissions()`:
+
+```javascript
+NotificationsIOS.checkPermissions().then((currentPermissions) => {
+    console.log('Badges enabled: ' + !!currentPermissions.badge);
+    console.log('Sounds enabled: ' + !!currentPermissions.sound);
+    console.log('Alerts enabled: ' + !!currentPermissions.alert);
+});
+```
+
 ### Android
 
 The React-Native code equivalent on Android is:

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -562,4 +562,14 @@ RCT_EXPORT_METHOD(isRegisteredForRemoteNotifications:(RCTPromiseResolveBlock)res
     resolve(@(ans));
 }
 
+RCT_EXPORT_METHOD(checkPermissions:(RCTPromiseResolveBlock) resolve
+                  reject:(RCTPromiseRejectBlock) reject) {
+    UIUserNotificationSettings *currentSettings = [[UIApplication sharedApplication] currentUserNotificationSettings];
+    resolve(@{
+              @"badge": @((currentSettings.types & UIUserNotificationTypeBadge) > 0),
+              @"sound": @((currentSettings.types & UIUserNotificationTypeSound) > 0),
+              @"alert": @((currentSettings.types & UIUserNotificationTypeAlert) > 0),
+              });
+}
+
 @end

--- a/index.ios.js
+++ b/index.ios.js
@@ -212,4 +212,8 @@ export default class NotificationsIOS {
   static isRegisteredForRemoteNotifications() {
     return NativeRNNotifications.isRegisteredForRemoteNotifications();
   }
+
+  static checkPermissions() {
+    return NativeRNNotifications.checkPermissions();
+  }
 }

--- a/test/index.ios.spec.js
+++ b/test/index.ios.spec.js
@@ -29,7 +29,8 @@ describe("NotificationsIOS", () => {
     nativeCancelLocalNotification,
     nativeCancelAllLocalNotifications,
     nativeSetBadgesCount,
-    nativeIsRegisteredForRemoteNotifications;
+    nativeIsRegisteredForRemoteNotifications,
+    nativeCheckPermissions;
 
   let NotificationsIOS, NotificationAction, NotificationCategory;
   let someHandler = () => {};
@@ -51,6 +52,7 @@ describe("NotificationsIOS", () => {
     nativeCancelAllLocalNotifications = sinon.spy();
     nativeSetBadgesCount = sinon.spy();
     nativeIsRegisteredForRemoteNotifications = sinon.spy();
+    nativeCheckPermissions = sinon.spy();
 
     let libUnderTest = proxyquire("../index.ios", {
       "uuid": {
@@ -69,7 +71,7 @@ describe("NotificationsIOS", () => {
             cancelAllLocalNotifications: nativeCancelAllLocalNotifications,
             setBadgesCount: nativeSetBadgesCount,
             isRegisteredForRemoteNotifications: nativeIsRegisteredForRemoteNotifications,
-            checkPermissions: nativeCheckPermissions,
+            checkPermissions: nativeCheckPermissions
           }
         },
         NativeAppEventEmitter: {
@@ -109,6 +111,7 @@ describe("NotificationsIOS", () => {
     nativeCancelLocalNotification.reset();
     nativeCancelAllLocalNotifications.reset();
     nativeIsRegisteredForRemoteNotifications.reset();
+    nativeCheckPermissions.reset();
   });
 
   after(() => {
@@ -125,6 +128,7 @@ describe("NotificationsIOS", () => {
     nativeCancelLocalNotification = null;
     nativeCancelAllLocalNotifications = null;
     nativeIsRegisteredForRemoteNotifications = null;
+    nativeCheckPermissions = null;
 
     NotificationsIOS = null;
     NotificationAction = null;

--- a/test/index.ios.spec.js
+++ b/test/index.ios.spec.js
@@ -68,7 +68,8 @@ describe("NotificationsIOS", () => {
             cancelLocalNotification: nativeCancelLocalNotification,
             cancelAllLocalNotifications: nativeCancelAllLocalNotifications,
             setBadgesCount: nativeSetBadgesCount,
-            isRegisteredForRemoteNotifications: nativeIsRegisteredForRemoteNotifications
+            isRegisteredForRemoteNotifications: nativeIsRegisteredForRemoteNotifications,
+            checkPermissions: nativeCheckPermissions,
           }
         },
         NativeAppEventEmitter: {
@@ -306,6 +307,14 @@ describe("NotificationsIOS", () => {
     it("should call native is registered for remote notifications", () => {
       NotificationsIOS.isRegisteredForRemoteNotifications();
       expect(nativeIsRegisteredForRemoteNotifications).to.have.been.calledWith();
+
+    });
+  });
+
+  describe("Check permissions ", () => {
+    it("should call native check permissions", () => {
+      NotificationsIOS.checkPermissions();
+      expect(nativeCheckPermissions).to.have.been.calledWith();
 
     });
   });


### PR DESCRIPTION
Add a checkPermissions function allowing the app to determine what
notification permissions the user has granted. The function returns a
promise resolving to an object with permission info.