### PR TITLE
Remove createJSModules @overide marker - RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -26,7 +26,7 @@ public class RNNotificationsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext));
     }
 
-    @Override
+    // RN 0.47 compatibility
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -26,7 +26,7 @@ public class RNNotificationsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext));
     }
 
-    // RN 0.47 compatibility
+    // Deprecated from RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method. This change is backwards compatible.