### PR TITLE
dont ignore 'repeatInterval'

### DIFF
--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -27,6 +27,24 @@ NSString* const RNNotificationReceivedBackground = @"RNNotificationReceivedBackg
 NSString* const RNNotificationOpened = @"RNNotificationOpened";
 NSString* const RNNotificationActionTriggered = @"RNNotificationActionTriggered";
 
+#if !TARGET_OS_TV
+@implementation RCTConvert (NSCalendarUnit)
+
+RCT_ENUM_CONVERTER(NSCalendarUnit,
+                   (@{
+                      @"year": @(NSCalendarUnitYear),
+                      @"month": @(NSCalendarUnitMonth),
+                      @"week": @(NSCalendarUnitWeekOfYear),
+                      @"day": @(NSCalendarUnitDay),
+                      @"hour": @(NSCalendarUnitHour),
+                      @"minute": @(NSCalendarUnitMinute)
+                      }),
+                   0,
+                   integerValue)
+
+@end
+#endif
+
 /*
  * Converters for Interactive Notifications
  */
@@ -102,6 +120,7 @@ RCT_ENUM_CONVERTER(UIUserNotificationActionBehavior, (@{
     notification.soundName = [RCTConvert NSString:details[@"soundName"]] ?: UILocalNotificationDefaultSoundName;
     notification.userInfo = [RCTConvert NSDictionary:details[@"userInfo"]] ?: @{};
     notification.category = [RCTConvert NSString:details[@"category"]];
+    notification.repeatInterval = [RCTConvert NSCalendarUnit:details[@"repeatInterval"]];
 
     return notification;
 }


### PR DESCRIPTION
react-native now allows you to specify a 'repeatInterval' for local notifications [defined here](https://github.com/facebook/react-native/blob/master/Libraries/PushNotificationIOS/RCTPushNotificationManager.m#L61).  But currently react-native-notifications obliterates that attribute when it *also* implements `+ (UILocalNotification *)UILocalNotification:(id)json` and doesn't persist 'repeatInterval'.  Effectively, repeating local notifications is currently busted if you use RNN.  This update will copy the same functionality as the existing react-native version of `+ (UILocalNotification *)UILocalNotification:(id)json`, and therefore passing the value of 'repeatInterval' onto the notification.