### PR TITLE
Minimum changes for large and small icon to be set

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -26,7 +26,7 @@ public class RNNotificationsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext));
     }
 
-    @Override
+    // Deprecated - React Native 0.47+
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -144,7 +144,7 @@ public class PushNotification implements IPushNotification {
                 .setContentTitle(mNotificationProps.getTitle())
                 .setContentText(mNotificationProps.getBody())
                 .setSmallIcon(mContext.getApplicationInfo().icon)
-                .setLargeIcon(BitmapFactory.decodeResource(mContext.getApplicationInfo().icon))
+                .setLargeIcon(BitmapFactory.decodeResource(mContext.getResources(), mContext.getApplicationInfo().icon))
                 .setContentIntent(intent)
                 .setSound(defaultSoundUri)
                 .setDefaults(Notification.DEFAULT_ALL)

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -136,11 +136,14 @@ public class PushNotification implements IPushNotification {
     }
 
     protected Notification.Builder getNotificationBuilder(PendingIntent intent) {
+        Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         return new Notification.Builder(mContext)
                 .setContentTitle(mNotificationProps.getTitle())
                 .setContentText(mNotificationProps.getBody())
                 .setSmallIcon(mContext.getApplicationInfo().icon)
+                .setLargeIcon(BitmapFactory.decodeResource(mContext.getApplicationInfo().icon))
                 .setContentIntent(intent)
+                .setSound(defaultSoundUri)
                 .setDefaults(Notification.DEFAULT_ALL)
                 .setAutoCancel(true);
     }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -143,7 +143,7 @@ public class PushNotification implements IPushNotification {
         return new Notification.Builder(mContext)
                 .setContentTitle(mNotificationProps.getTitle())
                 .setContentText(mNotificationProps.getBody())
-                .setSmallIcon(mContext.getApplicationInfo().icon)
+                .setSmallIcon(mNotificationProps.hasSmallIcon() ? mContext.getResources().getIdentifier(mNotificationProps.getSmallIcon(), null, mContext.getPackageName()) : mContext.getApplicationInfo().icon)
                 .setLargeIcon(BitmapFactory.decodeResource(mContext.getResources(), mContext.getApplicationInfo().icon))
                 .setContentIntent(intent)
                 .setSound(defaultSoundUri)

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -5,6 +5,9 @@ import android.app.NotificationManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.BitmapFactory;
+import android.media.RingtoneManager;
+import android.net.Uri;
 import android.os.Bundle;
 
 import com.facebook.react.bridge.ReactContext;

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -10,10 +10,11 @@ public class PushNotificationProps {
         mBundle = new Bundle();
     }
 
-    public PushNotificationProps(String title, String body) {
+    public PushNotificationProps(String title, String body, String smallIcon) {
         mBundle = new Bundle();
         mBundle.putString("title", title);
         mBundle.putString("body", body);
+        mBundle.putString("smallIcon", smallIcon);
     }
 
     public PushNotificationProps(Bundle bundle) {
@@ -26,6 +27,14 @@ public class PushNotificationProps {
 
     public String getBody() {
         return mBundle.getString("body");
+    }
+
+    public boolean hasSmallIcon() {
+        return mBundle.containsKey("smallIcon");
+    }
+
+    public String getSmallIcon() {
+        return mBundle.getString("smallIcon");
     }
 
     public Bundle asBundle() {


### PR DESCRIPTION
Hi, 

I needed to be able to set the large icon and small icon correctly (our app launcher icon doesn't meet requirements to be displayed as a true status bar icon).

Mostly putting this here in case anyone else needs the _absolute bare minimum_ for this, as I'm really eager to see https://github.com/wix/react-native-notifications/pull/71 get merged in (that PR is 👌 ). In the interim, however, here is minor changes for these needs. 

Please ignore/close if/when https://github.com/wix/react-native-notifications/pull/71 is likely to get merged.