### PR TITLE
Remove @providesModule

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -1,5 +1,4 @@
 /**
- * @providesModule RNNotifications
  * @flow
  */
 "use strict";


### PR DESCRIPTION
This fixes Flow errors relating to `Duplicate module provider`: 

```bash
$ flow
Error: node_modules/react-native-notifications/index.ios.js:0
RNNotifications. Duplicate module provider
current provider. See: ios/node_modules/react-native-notifications/index.ios.js:0
```

[`@providesModule` is not meant to be used by systems outside of Facebook.](https://github.com/facebook/flow/issues/2648#issuecomment-254883663)

This Haste module is never used by the library, and only interferes with usage in Haste-based systems.
