### PR TITLE
Upgrade core-js

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "nativePackage": true,
   "dependencies": {
-    "core-js": "^1.0.0",
+    "core-js": "^2.4.0",
     "uuid": "^2.0.3"
   },
   "peerDependencies": {


### PR DESCRIPTION
This is a very simple upgrade.
Current codebase just use map so the upgrade is safe as the only import used it working in latest version. https://unpkg.com/core-js@2.5.1/library/es6/map.js

The motivation for this upgrade is that I am facing a bug with yarn. I won't explain the bug but it's just that in my edge case, I have a conflict with core-js^1 & 2. This PR will help me :)

For everyone, it might just reduce the size of node_modules as core-js^2 is widely used atm :)