### PR TITLE
Fix android package for React Native 0.47 and newer

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -26,7 +26,6 @@ public class RNNotificationsPackage implements ReactPackage {
         return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext));
     }
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
React Native 0.47 and newer throw error `method does not override or implement a method from a supertype` for `@Override ....`. So I just deleted that line.