### PR TITLE
iOS opening Local Notification crash fix

### DIFF
--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -62,9 +62,7 @@ RCT_ENUM_CONVERTER(UIUserNotificationActionBehavior, (@{
 
     UIMutableUserNotificationAction* action =[UIMutableUserNotificationAction new];
     action.activationMode = [RCTConvert UIUserNotificationActivationMode:details[@"activationMode"]];
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
-        action.behavior = [RCTConvert UIUserNotificationActionBehavior:details[@"behavior"]];
-    }
+    action.behavior = [RCTConvert UIUserNotificationActionBehavior:details[@"behavior"]];
     action.authenticationRequired = [RCTConvert BOOL:details[@"authenticationRequired"]];
     action.destructive = [RCTConvert BOOL:details[@"destructive"]];
     action.title = [RCTConvert NSString:details[@"title"]];
@@ -102,9 +100,7 @@ RCT_ENUM_CONVERTER(UIUserNotificationActionBehavior, (@{
     UILocalNotification* notification = [UILocalNotification new];
     notification.fireDate = [RCTConvert NSDate:details[@"fireDate"]];
     notification.alertBody = [RCTConvert NSString:details[@"alertBody"]];
-    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.2")) {
-        notification.alertTitle = [RCTConvert NSString:details[@"alertTitle"]];
-    }
+    notification.alertTitle = [RCTConvert NSString:details[@"alertTitle"]];
     notification.alertAction = [RCTConvert NSString:details[@"alertAction"]];
     notification.soundName = [RCTConvert NSString:details[@"soundName"]] ?: UILocalNotificationDefaultSoundName;
     if ([RCTConvert BOOL:details[@"silent"]]) {

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -222,7 +222,8 @@ RCT_EXPORT_MODULE()
                                                object:nil];
 
     [RNNotificationsBridgeQueue sharedInstance].openedRemoteNotification = [_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
-    [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = [_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
+    UILocalNotification *localNotification = [_bridge.launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
+    [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = localNotification ? localNotification.userInfo : nil;
 }
 
 /*

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -62,7 +62,9 @@ RCT_ENUM_CONVERTER(UIUserNotificationActionBehavior, (@{
 
     UIMutableUserNotificationAction* action =[UIMutableUserNotificationAction new];
     action.activationMode = [RCTConvert UIUserNotificationActivationMode:details[@"activationMode"]];
-    action.behavior = [RCTConvert UIUserNotificationActionBehavior:details[@"behavior"]];
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"9.0")) {
+        action.behavior = [RCTConvert UIUserNotificationActionBehavior:details[@"behavior"]];
+    }
     action.authenticationRequired = [RCTConvert BOOL:details[@"authenticationRequired"]];
     action.destructive = [RCTConvert BOOL:details[@"destructive"]];
     action.title = [RCTConvert NSString:details[@"title"]];
@@ -100,7 +102,9 @@ RCT_ENUM_CONVERTER(UIUserNotificationActionBehavior, (@{
     UILocalNotification* notification = [UILocalNotification new];
     notification.fireDate = [RCTConvert NSDate:details[@"fireDate"]];
     notification.alertBody = [RCTConvert NSString:details[@"alertBody"]];
-    notification.alertTitle = [RCTConvert NSString:details[@"alertTitle"]];
+    if (SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(@"8.2")) {
+        notification.alertTitle = [RCTConvert NSString:details[@"alertTitle"]];
+    }
     notification.alertAction = [RCTConvert NSString:details[@"alertAction"]];
     notification.soundName = [RCTConvert NSString:details[@"soundName"]] ?: UILocalNotificationDefaultSoundName;
     if ([RCTConvert BOOL:details[@"silent"]]) {


### PR DESCRIPTION
Adjust the setting of the `openedLocalNotification` from `launchOptions` to use the `userInfo` from the `UILocalNotification` if it exists instead of the `UILocalNotification` itself. This prevents `null` from being passed through to the `IOSNotification` constructor which causes the crash described in #83 when an app is opened fresh versus being resumed from the background.

When comparing to how remote notifications are handled, `UIApplicationLaunchOptionsRemoteNotificationKey` returns "an NSDictionary containing the payload of the remote notification" where `UIApplicationLaunchOptionsLocalNotificationKey` returns a `UILocalNotification` as mentioned so using the `userInfo` dictionary is the most appropriate option to allow the rest of the notification handling flow to function.