### PR TITLE
make requestPermissions as a promise. it resolves with notificationSettings data

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -138,7 +138,7 @@ export default class NotificationsIOS {
       });
     }
 
-    NativeRNNotifications.requestPermissionsWithCategories(notificationCategories);
+    return NativeRNNotifications.requestPermissionsWithCategories(notificationCategories);
   }
 
   /**


### PR DESCRIPTION
Current requestpermissions is a just function. If user rejects or permissions were previously rejected, nothing happens (no event, no result..).

But requestpermissions  of [react-native's PushNotificationIOS](https://facebook.github.io/react-native/docs/pushnotificationios.html#requestpermissions) is promise, which returns a promise that will resolve when the user accepts, rejects, or if the permissions were previously rejected. The promise resolves to the current state of the permission.

So I just want to make it works same. :)
