### PR TITLE
Error handling onMessageReceived()

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/gcm/GcmMessageHandlerService.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/gcm/GcmMessageHandlerService.java
@@ -22,5 +22,9 @@ public class GcmMessageHandlerService extends GcmListenerService {
             // A GCM message, yes - but not the kind we know how to work with.
             Log.v(LOGTAG, "GCM message handling aborted", e);
         }
+         catch (Exception e) {
+            // Handle other errors, i.e when app is not running
+            Log.v(LOGTAG, "GCM message handling aborted", e);
+        }
     }
 }


### PR DESCRIPTION
Handle other exceptions to prevent app from crashing when receiving push when app is not runnign