### PR TITLE
PR from the issue #92 ( Notification duplicate on android )

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -57,7 +57,6 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public void onReceived() throws InvalidNotificationException {
-        postNotification(null);
         notifyReceivedToJS();
     }
 


### PR DESCRIPTION
-Added fix to remove the duplicate local notification generated on receiving the push notification from gcm.