### PR TITLE
Update notificationsEvents.md

### DIFF
--- a/docs/notificationsEvents.md
+++ b/docs/notificationsEvents.md
@@ -14,9 +14,13 @@ Example:
 
 ```javascript
 constructor() {
-	NotificationsIOS.addEventListener('notificationReceivedForeground', this.onNotificationReceivedForeground.bind(this));
-    NotificationsIOS.addEventListener('notificationReceivedBackground', this.onNotificationReceivedBackground.bind(this));
-    NotificationsIOS.addEventListener('notificationOpened', this.onNotificationOpened.bind(this));
+    this._boundOnNotificationReceivedForeground = this.onNotificationReceivedForeground.bind(this);
+    this._boundOnNotificationReceivedBackground = this.onNotificationReceivedBackground.bind(this);
+    this._boundOnNotificationOpened = this.onNotificationOpened.bind(this);
+    
+    NotificationsIOS.addEventListener('notificationReceivedForeground', this._boundOnNotificationReceivedForeground);
+    NotificationsIOS.addEventListener('notificationReceivedBackground', this._boundOnNotificationReceivedBackground);
+    NotificationsIOS.addEventListener('notificationOpened', this._boundOnNotificationOpened);
 }
 
 onNotificationReceivedForeground(notification) {
@@ -33,9 +37,9 @@ onNotificationOpened(notification) {
 
 componentWillUnmount() {
 	// Don't forget to remove the event listeners to prevent memory leaks!
-	NotificationsIOS.removeEventListener('notificationReceivedForeground', this.onNotificationReceivedForeground.bind(this));
-	NotificationsIOS.removeEventListener('notificationReceivedBackground', this.onNotificationReceivedBackground.bind(this));
-	NotificationsIOS.removeEventListener('notificationOpened', this.onNotificationOpened.bind(this));
+	NotificationsIOS.removeEventListener('notificationReceivedForeground', this._boundOnNotificationReceivedForeground);
+	NotificationsIOS.removeEventListener('notificationReceivedBackground', this._boundOnNotificationReceivedBackground);
+	NotificationsIOS.removeEventListener('notificationOpened', this._boundOnNotificationOpened);
 }
 ```
 


### PR DESCRIPTION
Changes the documentation so the example is correct in the prevention of the memory leaks.

`.bind` will return a new version of the function on each call which means `removeEventListener` won't be able to find the previous listener and release it.