### PR TITLE
Add option to not clear all notifications on resume/open

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ _Upcoming: local notifications, background-state Rx queue (iOS equivalent)_
 - [Local notifications](./docs/localNotifications.md) - Manually triggering notifications (i.e. not via push)
 - [Advanced iOS topics](./docs/advancedIos.md) - e.g. managed notifications, PushKit API, Notifications actions
 - [Notifications layout control - Android (wiki page)](https://github.com/wix/react-native-notifications/wiki/Android:-Layout-Customization) - Learn how to fully customize your notifications layout on Android!
+- [Customize how your app dismisses (or not) notifications on Open/Resume](./docs/androidAppOpenBehaviour.md)
 
 # License
 The MIT License.

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -29,8 +29,14 @@ import static com.wix.reactnativenotifications.Defs.LOGTAG;
 
 public class RNNotificationsModule extends ReactContextBaseJavaModule implements AppLifecycleFacade.AppVisibilityListener, Application.ActivityLifecycleCallbacks {
 
-    public RNNotificationsModule(Application application, ReactApplicationContext reactContext) {
+    private final boolean mClearAllNotificationsOnInit;
+    private final boolean mClearAllNotificationsOnResume;
+
+    public RNNotificationsModule(Application application, ReactApplicationContext reactContext, boolean clearNotificationsOnInit, boolean clearNotificationsOnResume) {
         super(reactContext);
+
+        mClearAllNotificationsOnInit = clearNotificationsOnInit;
+        mClearAllNotificationsOnResume = clearNotificationsOnResume;
 
         if (AppLifecycleFacadeHolder.get() instanceof ReactAppLifecycleFacade) {
             ((ReactAppLifecycleFacade) AppLifecycleFacadeHolder.get()).init(reactContext);
@@ -50,7 +56,7 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
         startGcmIntentService(GcmInstanceIdRefreshHandlerService.EXTRA_IS_APP_INIT);
 
         final IPushNotificationsDrawer notificationsDrawer = PushNotificationsDrawer.get(getReactApplicationContext().getApplicationContext());
-        notificationsDrawer.onAppInit();
+        notificationsDrawer.onAppInit(mClearAllNotificationsOnInit);
     }
 
     @ReactMethod
@@ -99,7 +105,7 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     @Override
     public void onAppVisible() {
         final IPushNotificationsDrawer notificationsDrawer = PushNotificationsDrawer.get(getReactApplicationContext().getApplicationContext());
-        notificationsDrawer.onAppVisible();
+        notificationsDrawer.onAppVisible(mClearAllNotificationsOnResume);
     }
 
     @Override

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -14,14 +14,30 @@ import java.util.List;
 public class RNNotificationsPackage implements ReactPackage {
 
     private final Application mApplication;
+    private final boolean mClearNotificationsOnInit;
+    private final boolean mClearNotificationsOnResume;
 
     public RNNotificationsPackage(Application application) {
         mApplication = application;
+        mClearNotificationsOnInit = true;
+        mClearNotificationsOnResume = true;
+    }
+
+    public RNNotificationsPackage(Application application, boolean clearNotificationsOnInit) {
+        mApplication = application;
+        mClearNotificationsOnInit = clearNotificationsOnInit;
+        mClearNotificationsOnResume = true;
+    }
+
+    public RNNotificationsPackage(Application application, boolean clearNotificationsOnInit, boolean clearNotificationsOnResume) {
+        mApplication = application;
+        mClearNotificationsOnInit = clearNotificationsOnInit;
+        mClearNotificationsOnResume = clearNotificationsOnResume;
     }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-        return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext));
+        return Arrays.<NativeModule>asList(new RNNotificationsModule(mApplication, reactContext, mClearNotificationsOnInit, mClearNotificationsOnResume));
     }
 
     @Override

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/IPushNotificationsDrawer.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/IPushNotificationsDrawer.java
@@ -3,8 +3,8 @@ package com.wix.reactnativenotifications.core.notificationdrawer;
 import android.app.Activity;
 
 public interface IPushNotificationsDrawer {
-    void onAppInit();
-    void onAppVisible();
+    void onAppInit(boolean clearNotificationsOnInit);
+    void onAppVisible(boolean clearNotificationsOnAppVisible);
     void onNewActivity(Activity activity);
 
     void onNotificationOpened();

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
@@ -31,13 +31,17 @@ public class PushNotificationsDrawer implements IPushNotificationsDrawer {
     }
 
     @Override
-    public void onAppInit() {
-        clearAll();
+    public void onAppInit(boolean clearNotifications) {
+        if (clearNotifications) {
+            clearAll();
+        }
     }
 
     @Override
-    public void onAppVisible() {
-        clearAll();
+    public void onAppVisible(boolean clearNotifications) {
+        if (clearNotifications) {
+            clearAll();
+        }
     }
 
     @Override

--- a/docs/androidAppOpenBehaviour.md
+++ b/docs/androidAppOpenBehaviour.md
@@ -1,0 +1,54 @@
+# Customize how your app dismisses (or not) notifications on Open/Resume
+
+By default, when you have notifications in your notification drawer and open the app, all notifications are dismissed and disappear.
+
+In your application, you might want a different behavior.
+
+## <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/a/a0/APK_format_icon.png/768px-APK_format_icon.png" width=30/> Android only
+
+For that, you can pass two booleans when you initialize the package : 
+
+* The first one sets if you want to discard all notifications 
+
+```java
+public class MainApplication extends MultiDexApplication
+  implements ReactApplication, INotificationsApplication {
+
+  private final ReactNativeHost mReactNativeHost = new ReactNativeHost(this) {
+
+    @Override
+    protected String getJSBundleFile() {
+      return CodePush.getJSBundleFile();
+    }
+
+    @Override
+    public boolean getUseDeveloperSupport() {
+      return BuildConfig.DEBUG;
+    }
+
+    @Override
+    protected List<ReactPackage> getPackages() {
+      return Arrays.<ReactPackage>asList(
+        new MainReactPackage(),
+        ...,
+        new RNNotificationsPackage(MainApplication.this) // Default
+        // new RNNotificationsPackage(MainApplication.this, false) // If you want to discard them on Resume but not on Init
+        // new RNNotificationsPackage(MainApplication.this, true, false) // If you want to discard notifications when opening the app (cold boot) but not on Resume
+        // new RNNotificationsPackage(MainApplication.this, false, false) // If you never want to discard notifications when opening the app
+      );
+    }
+  };
+
+  @Override
+  public ReactNativeHost getReactNativeHost() {
+    return mReactNativeHost;
+  }
+
+  @Override
+  public void onCreate() {
+    super.onCreate();
+
+    SoLoader.init(this, /* native exopackage */ false);
+  }
+}
+```


### PR DESCRIPTION
By default, when we open the app, all notifications of the app are cleared.

We needed to change that behavior, so we implemented it that way.

All comments/changes are welcome :)