### PR TITLE
Added method for getting the current iOS badge count

### DIFF
--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -533,6 +533,12 @@ RCT_EXPORT_METHOD(registerPushKit)
     [RNNotifications registerPushKit];
 }
 
+RCT_EXPORT_METHOD(getBadgesCount:(RCTResponseSenderBlock)callback)
+{
+    NSInteger count = [UIApplication sharedApplication].applicationIconBadgeNumber;
+    callback(@[ [NSNumber numberWithInteger:count] ]);
+}
+
 RCT_EXPORT_METHOD(setBadgesCount:(int)count)
 {
     [[UIApplication sharedApplication] setApplicationIconBadgeNumber:count];

--- a/docs/advancedIos.md
+++ b/docs/advancedIos.md
@@ -260,7 +260,12 @@ The [example app](https://github.com/wix/react-native-notifications/tree/master/
 	- `minimal` - Displays up tp 2 actions (minimal UI).
 
 	
-#### Set application icon badges count (iOS only) 
+#### Get and set application icon badges count (iOS only) 
+
+Get the current number:
+```javascript
+NotificationsIOS.getBadgesCount((count) => console.log(count));
+```
 
 Set to specific number: 
 ```javascript

--- a/index.ios.js
+++ b/index.ios.js
@@ -160,6 +160,10 @@ export default class NotificationsIOS {
     _actionHandlers.clear();
   }
 
+  static getBadgesCount(callback: Function) {
+    NativeRNNotifications.getBadgesCount(callback);
+  }
+
   static setBadgesCount(count: number) {
     NativeRNNotifications.setBadgesCount(count);
   }

--- a/test/index.ios.spec.js
+++ b/test/index.ios.spec.js
@@ -28,6 +28,7 @@ describe("NotificationsIOS", () => {
     nativeLocalNotification,
     nativeCancelLocalNotification,
     nativeCancelAllLocalNotifications,
+    nativeGetBadgesCount,
     nativeSetBadgesCount,
     nativeIsRegisteredForRemoteNotifications,
     nativeCheckPermissions,
@@ -54,6 +55,7 @@ describe("NotificationsIOS", () => {
     nativeLocalNotification = sinon.spy();
     nativeCancelLocalNotification = sinon.spy();
     nativeCancelAllLocalNotifications = sinon.spy();
+    nativeGetBadgesCount = sinon.spy();
     nativeSetBadgesCount = sinon.spy();
     nativeIsRegisteredForRemoteNotifications = sinon.spy();
     nativeCheckPermissions = sinon.spy();
@@ -76,6 +78,7 @@ describe("NotificationsIOS", () => {
             localNotification: nativeLocalNotification,
             cancelLocalNotification: nativeCancelLocalNotification,
             cancelAllLocalNotifications: nativeCancelAllLocalNotifications,
+            getBadgesCount: nativeGetBadgesCount,
             setBadgesCount: nativeSetBadgesCount,
             isRegisteredForRemoteNotifications: nativeIsRegisteredForRemoteNotifications,
             checkPermissions: nativeCheckPermissions,
@@ -236,6 +239,15 @@ describe("NotificationsIOS", () => {
         NotificationsIOS.resetCategories();
 
         expect(nativeAppRemoveEventListener).to.have.been.calledOnce;
+      });
+    });
+
+    describe("get badges count", () => {
+      it("should call native getBadgesCount", () => {
+        const callback = (count) => console.log(count);
+        NotificationsIOS.getBadgesCount(callback);
+
+        expect(nativeGetBadgesCount).to.have.been.calledWith(callback);
       });
     });
 


### PR DESCRIPTION
This PR adds a method for getting the current badge count, which could be useful for incrementing / decrementing the badge count.