### PR TITLE
Update docs to include information about removing android event listeners

### DIFF
--- a/docs/notificationsEvents.md
+++ b/docs/notificationsEvents.md
@@ -77,6 +77,13 @@ NotificationsAndroid.setNotificationOpenedListener((notification) => {
 });
 ```
 
+You can also remove the event listeners when they are no longer needed:
+
+```javascript
+NotificationsAndroid.clearNotificationReceivedListener();
+NotificationsAndroid.clearNotificationOpenedListener();
+```
+
 ### Notification Object
 
 - **`getData()`**- content of the `data` section of the original message (sent to GCM).

--- a/docs/notificationsEvents.md
+++ b/docs/notificationsEvents.md
@@ -80,6 +80,7 @@ NotificationsAndroid.setNotificationOpenedListener((notification) => {
 You can also remove the event listeners when they are no longer needed:
 
 ```javascript
+NotificationsAndroid.clearRegistrationTokenUpdateListener();
 NotificationsAndroid.clearNotificationReceivedListener();
 NotificationsAndroid.clearNotificationOpenedListener();
 ```


### PR DESCRIPTION
Found those methods in the tests when looking for a way to remove the listeners in my app when the user is logged out. I think it's worth including them in the README.