### PR TITLE
Podspec: prepend 'v' to version tag

### DIFF
--- a/react-native-notifications.podspec
+++ b/react-native-notifications.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.license        = package['license']
   s.author         = package['author']
   s.homepage       = package['homepage']
-  s.source         = { :git => 'https://github.com/wix/react-native-notifications', :tag => s.version }
+  s.source         = { :git => 'https://github.com/wix/react-native-notifications', :tag => "v#{s.version}" }
 
   s.requires_arc   = true
   s.platform       = :ios, '8.0'


### PR DESCRIPTION
Fixes CocoaPods install. Previously it was trying to fetch git tags like '1.1.19'. This fixes it so it fetches 'v1.1.19' instead.

You'll also need to push git tags for the latest versions to make it work.