### PR TITLE
[Android] Always get all Push-Notifications however you start the App

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -97,6 +97,12 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     }
 
     @ReactMethod
+    public void cancelAllNotifications() {
+        IPushNotificationsDrawer notificationsDrawer = PushNotificationsDrawer.get(getReactApplicationContext().getApplicationContext());
+        notificationsDrawer.clearAll();
+    }
+
+    @ReactMethod
     public void isRegisteredForRemoteNotifications(Promise promise) {
         boolean hasPermission = NotificationManagerCompat.from(getReactApplicationContext()).areNotificationsEnabled();
         promise.resolve(new Boolean(hasPermission));

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -1,5 +1,8 @@
 package com.wix.reactnativenotifications;
 
+import java.util.List;
+import java.util.ArrayList;
+
 import android.app.Activity;
 import android.app.Application;
 import android.content.Context;
@@ -62,17 +65,20 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     @ReactMethod
     public void getInitialNotification(final Promise promise) {
         Log.d(LOGTAG, "Native method invocation: getInitialNotification");
-        Object result = null;
+        List<Object> result = new ArrayList<Object>();
 
         try {
-            final PushNotificationProps notification = InitialNotificationHolder.getInstance().get();
-            if (notification == null) {
+            final List<PushNotificationProps> notifications = InitialNotificationHolder.getInstance().get();
+            if (notifications == null) {
                 return;
             }
 
-            result = Arguments.fromBundle(notification.asBundle());
+            for(PushNotificationProps props: notifications){
+                result.add(Arguments.fromBundle(props.asBundle()));
+            }
         } finally {
-            promise.resolve(result);
+            promise.resolve(Arguments.makeNativeArray(result));
+            InitialNotificationHolder.getInstance().clear();
         }
     }
 

--- a/android/src/main/java/com/wix/reactnativenotifications/core/InitialNotificationHolder.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/InitialNotificationHolder.java
@@ -1,5 +1,8 @@
 package com.wix.reactnativenotifications.core;
 
+import java.util.List;
+import java.util.ArrayList;
+
 import android.support.annotation.Nullable;
 
 import com.wix.reactnativenotifications.core.notification.PushNotificationProps;
@@ -8,7 +11,7 @@ public class InitialNotificationHolder {
 
     private static InitialNotificationHolder sInstance;
 
-    private PushNotificationProps mNotification;
+    private List<PushNotificationProps> mNotificationArray = new ArrayList<PushNotificationProps>();
 
     public static void setInstance(InitialNotificationHolder instance) {
         sInstance = instance;
@@ -25,15 +28,15 @@ public class InitialNotificationHolder {
     }
 
     public void set(PushNotificationProps pushNotificationProps) {
-        mNotification = pushNotificationProps;
+        mNotificationArray.add(pushNotificationProps);
     }
 
     public void clear() {
-        mNotification = null;
+        mNotificationArray.clear();
     }
 
     @Nullable
-    public PushNotificationProps get() {
-        return mNotification;
+    public List<PushNotificationProps> get() {
+        return mNotificationArray;
     }
 }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/InitialNotificationHolder.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/InitialNotificationHolder.java
@@ -2,6 +2,7 @@ package com.wix.reactnativenotifications.core;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.HashMap;
 
 import android.support.annotation.Nullable;
 
@@ -11,7 +12,7 @@ public class InitialNotificationHolder {
 
     private static InitialNotificationHolder sInstance;
 
-    private List<PushNotificationProps> mNotificationArray = new ArrayList<PushNotificationProps>();
+    private HashMap<String,PushNotificationProps> mNotifications = new HashMap<String,PushNotificationProps>();
 
     public static void setInstance(InitialNotificationHolder instance) {
         sInstance = instance;
@@ -28,15 +29,15 @@ public class InitialNotificationHolder {
     }
 
     public void set(PushNotificationProps pushNotificationProps) {
-        mNotificationArray.add(pushNotificationProps);
+        mNotifications.put(pushNotificationProps.toString(),pushNotificationProps);
     }
 
     public void clear() {
-        mNotificationArray.clear();
+        mNotifications.clear();
     }
 
     @Nullable
     public List<PushNotificationProps> get() {
-        return mNotificationArray;
+        return new ArrayList<PushNotificationProps>(mNotifications.values());
     }
 }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -53,7 +53,7 @@ public class PushNotification implements IPushNotification {
         mAppLaunchHelper = appLaunchHelper;
         mJsIOHelper = JsIOHelper;
         mNotificationProps = createProps(bundle);
-		setAsInitialNotification();
+        setAsInitialNotification();
     }
 
     @Override

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -53,6 +53,7 @@ public class PushNotification implements IPushNotification {
         mAppLaunchHelper = appLaunchHelper;
         mJsIOHelper = JsIOHelper;
         mNotificationProps = createProps(bundle);
+		setAsInitialNotification();
     }
 
     @Override
@@ -85,15 +86,15 @@ public class PushNotification implements IPushNotification {
 
     protected void digestNotification() {
         if (!mAppLifecycleFacade.isReactInitialized()) {
-            setAsInitialNotification();
+            //setAsInitialNotification();
             launchOrResumeApp();
             return;
         }
 
-        final ReactContext reactContext = mAppLifecycleFacade.getRunningReactContext();
+        /*final ReactContext reactContext = mAppLifecycleFacade.getRunningReactContext();
         if (reactContext.getCurrentActivity() == null) {
             setAsInitialNotification();
-        }
+        }*/
 
         if (mAppLifecycleFacade.isAppVisible()) {
             dispatchImmediately();

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -64,6 +64,7 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public void onOpened() {
+        mNotificationProps.setOpened();
         digestNotification();
         clearAllNotifications();
     }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -32,6 +32,10 @@ public class PushNotificationProps {
         return (Bundle) mBundle.clone();
     }
 
+    public void setOpened(){
+        mBundle.putByte("opened", (byte) 1);
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder(1024);

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/IPushNotificationsDrawer.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/IPushNotificationsDrawer.java
@@ -9,4 +9,5 @@ public interface IPushNotificationsDrawer {
 
     void onNotificationOpened();
     void onNotificationClearRequest(int id);
+    void clearAll();
 }

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
@@ -60,7 +60,8 @@ public class PushNotificationsDrawer implements IPushNotificationsDrawer {
         notificationManager.cancel(id);
     }
 
-    protected void clearAll() {
+    @Override
+    public void clearAll() {
         final NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancelAll();
     }

--- a/index.android.js
+++ b/index.android.js
@@ -58,6 +58,10 @@ export class NotificationsAndroid {
   static cancelLocalNotification(id) {
     RNNotifications.cancelLocalNotification(id);
   }
+
+  static cancelAllNotifications() {
+    RNNotifications.cancelAllNotifications();
+  }
 }
 
 export class PendingNotifications {


### PR DESCRIPTION
We use Push-Notifications to transport Data. Therefore we are required to catch them all™.

This PR is not for merging - its an dirty fix for our Problem.

### Problem https://github.com/wix/react-native-notifications/issues/232
On Android ```getInitialNotification()``` contains the one Notification you clicked or no Notifiation at all if you start the App manually and Pushs are present.
On the other Hand all Notifications are cleared whatsoever.
Since we use Pushs as Data-Transport for Privacy reasons we need them all.

### Solution
InitialNotificationHolder now has an ArrayList of all incomming Notifications [look here](https://github.com/demokratie-live/react-native-notifications/commit/2ef1623664f48631a3008274fe966a0cfe917ea6#diff-1d481b699d468dd3a399fa59e84411dfR14)

setAsInitialNotification is now called upon constructing the PushNotification rather then doing it conditionally in digestNotification [look here](https://github.com/demokratie-live/react-native-notifications/commit/2ef1623664f48631a3008274fe966a0cfe917ea6#diff-2b9d975533bc41008db66e41f6cad4e2R56)

All User-Canceled Notifications are now also transfered to the App when its started the next time (which might be also a shortcomming)

### Shortcomings

We use [java.util.ArrayList](https://github.com/demokratie-live/react-native-notifications/commit/2ef1623664f48631a3008274fe966a0cfe917ea6#diff-1d481b699d468dd3a399fa59e84411dfR4) which might be a bad idea

If you click on the Notification it is now twice in the Array transfered to React-Native.
This is not cool - but we want you Experts to look into this and tell us the best Solution rather then
implementing a Hashmap Javaside - which makes the code more complicated - and we are aware that our solution might not be THE solution.

Maybe it would be wise to seperate the functionality into two functions:
- getInitialNotification()
- getAllNotifications()


Further read:
- https://github.com/wix/react-native-notifications/issues/143
- https://github.com/wix/react-native-notifications/issues/6
- https://github.com/wix/react-native-notifications/issues/126
- https://github.com/wix/react-native-notifications/issues/66
- https://github.com/wix/react-native-notifications/pull/185
- https://github.com/wix/react-native-notifications/blob/master/docs/notificationsEvents.md#-android
- https://developer.android.com/reference/android/app/Notification.html#extras
- https://github.com/kaloncheung124/react-native-notifications/commit/1f10e052a526dcdecdaa000e32ca087f77936049
- https://github.com/mattermost/mattermost-mobile/blob/master/android/app/src/main/java/com/mattermost/rnbeta/CustomPushNotification.java#L78
- https://stackoverflow.com/questions/28091784/multiple-pending-intents
- https://stackoverflow.com/questions/7370324/notification-passes-old-intent-extras
- https://stackoverflow.com/questions/3168484/pendingintent-works-correctly-for-the-first-notification-but-incorrectly-for-the#comment3283736_3168653


Grüße Ulf & [Team DEMOCRACY](https://www.democracy-deutschland.de)

Rel: https://github.com/demokratie-live/react-native-notifications/commit/2ef1623664f48631a3008274fe966a0cfe917ea6
Rev: https://github.com/demokratie-live/react-native-notifications/tree/android-initial-all-notifications