### PR TITLE
remove action listeners on re-registration

### DIFF
--- a/index.ios.js
+++ b/index.ios.js
@@ -124,6 +124,7 @@ export default class NotificationsIOS {
 
     if (categories) {
       // subscribe once for all actions
+      NativeAppEventEmitter.removeAllListeners(DEVICE_NOTIFICATION_ACTION_RECEIVED);      
       _actionListener = NativeAppEventEmitter.addListener(DEVICE_NOTIFICATION_ACTION_RECEIVED, this._actionHandlerDispatcher.bind(this));
 
       notificationCategories = categories.map(category => {


### PR DESCRIPTION
If we want to modify categories and actions we have to call register agin with the new categories array. 
In that case we want to remove the previous listeners before resetting new dispatcher for actions