### PR TITLE
fix background PN is received as foreground

### DIFF
--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -576,7 +576,7 @@ RCT_EXPORT_METHOD(consumeBackgroundQueue)
 
     // Push background notifications to JS
     [[RNNotificationsBridgeQueue sharedInstance] consumeNotificationsQueue:^(NSDictionary* notification) {
-        [RNNotifications didReceiveRemoteNotification:notification];
+        [RNNotifications didReceiveNotificationOnBackgroundState:notification];
     }];
 
     // Push opened local notifications


### PR DESCRIPTION
for the first time. refs #268 
The `didReceiveRemoteNotification` method checks for the current app state which will be active when queue processing takes place and hence it wrongly emits the notification to JS as foreground. However at the exact time when the user opened the notification, the app was at the background hence this is a background notification by definition.

In other words, conceptually determining if the notification is background or foreground should NOT be based on the time it was consumed from the queue but on the time it was received. Practically, if it was queued, then the app must have been in the background ==> background notification.