### PR TITLE
Remove obsolete elements from manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -3,17 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.wix.reactnativenotifications">
 
-    <!--
-     Permissions required for enabling GCM.
-     -->
-    <permission
-        android:name="${applicationId}.permission.C2D_MESSAGE"
-        android:protectionLevel="signature" />
-    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
-
-    <!-- Ref: http://stackoverflow.com/questions/13602190/java-lang-securityexception-requires-vibrate-permission-on-jelly-bean-4-2 -->
-    <uses-permission android:name="android.permission.VIBRATE" android:maxSdkVersion="18" />
-
     <application>
 
         <!--


### PR DESCRIPTION
According to Google GCM to FCM Migration guide, the removed lines of code are no longer required. And could create duplicate notifications.
https://developers.google.com/cloud-messaging/android/android-migrate-fcm

I have run the library in my local project after removing those lines, it works fine. 