### PR TITLE
[WIP] iOS deprecated API replacement

### DIFF
--- a/RNNotifications/RNNRouter.h
+++ b/RNNotifications/RNNRouter.h
@@ -17,7 +17,7 @@
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler;
-- (void)handlePushKitRegistered:(NSNotification *)notification;
+- (void)handlePushKitRegistered:(NSDictionary *)notification;
 
 @end
 
@@ -29,9 +29,11 @@
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(nullable void (^)(UIBackgroundFetchResult))completionHandler;
 - (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler;
 
 
 

--- a/RNNotifications/RNNRouter.h
+++ b/RNNotifications/RNNRouter.h
@@ -1,0 +1,34 @@
+//
+//  NRNNManager.h
+//  NRNNOtifications
+//
+//  Created by Muhammad Abed El Razek on 09/01/2019.
+//  Copyright © 2019 Wix. All rights reserved.
+//
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+#import <UserNotifications/UserNotifications.h>
+
+
+@protocol RNNRerouterDelegate <NSObject>
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler;
+
+@end
+
+@interface RNNRouter : NSObject<UNUserNotificationCenterDelegate>
+
++ (nonnull instancetype)sharedInstance;
+
+@property (nonatomic, weak) id <RNNRerouterDelegate> _Nullable delegate;
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
+
+
+
+@end

--- a/RNNotifications/RNNRouter.h
+++ b/RNNotifications/RNNRouter.h
@@ -8,6 +8,7 @@
 #import <UIKit/UIKit.h>
 #import <Foundation/Foundation.h>
 #import <UserNotifications/UserNotifications.h>
+#import <PushKit/PushKit.h>
 
 
 @protocol RNNRerouterDelegate <NSObject>
@@ -16,6 +17,7 @@
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler;
+- (void)handlePushKitRegistered:(NSNotification *)notification;
 
 @end
 
@@ -28,6 +30,8 @@
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
+- (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
+- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type;
 
 
 

--- a/RNNotifications/RNNRouter.m
+++ b/RNNotifications/RNNRouter.m
@@ -22,7 +22,7 @@
 @implementation RNNRouter
 
 + (nonnull instancetype)sharedInstance
-/Users/muhammadr/Desktop/Production/RNNotifions/react-native-notifications/example/node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj{
+{
     static RNNRouter* sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{

--- a/RNNotifications/RNNRouter.m
+++ b/RNNotifications/RNNRouter.m
@@ -7,7 +7,7 @@
 //
 
 #import "RNNRouter.h"
-
+#import "RNNotifications.h"
 //RNNNotifications's router (delegater) :::  singleton which routes all the static, system functions delegate calls to RNNNotifications insatnce ; can't have and RNNNotifications instance from outside of it's class
 
 
@@ -22,7 +22,7 @@
 @implementation RNNRouter
 
 + (nonnull instancetype)sharedInstance
-{
+/Users/muhammadr/Desktop/Production/RNNotifions/react-native-notifications/example/node_modules/react-native/Libraries/Vibration/RCTVibration.xcodeproj{
     static RNNRouter* sharedInstance = nil;
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
@@ -105,11 +105,6 @@
     }
 }
 
-
-/////////////////////////////////////////////////////////////////
-#pragma mark static calls for RNNNotifications rerouting purpous functions
-////////////////////////////////////////////////////////////////
-
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
     if (self.delegate != nil)
@@ -139,14 +134,16 @@
 {
     if(self.delegate != nil)
     {
-        //        [self.delegate handlePushKitRegistered:@{@"pushKitToken": [RNNotifications deviceTokenToString:credentials.token]}];
+        [self.delegate handlePushKitRegistered:@{@"pushKitToken": [RNNotifications deviceTokenToString:credentials.token]}];
     }
 }
 
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
 {
-    //TODO: check here
-    //    [RNNotifications didReceiveRemoteNotification:payload.dictionaryPayload];
+    if (self.delegate != nil)
+    {
+        [self.delegate application:nil didReceiveRemoteNotification:payload.dictionaryPayload fetchCompletionHandler:nil];
+    }
 }
 
 @end

--- a/RNNotifications/RNNRouter.m
+++ b/RNNotifications/RNNRouter.m
@@ -1,0 +1,141 @@
+//
+//  NRNNManager.m
+//  NRNNOtifications
+//
+//  Created by Muhammad Abed El Razek on 09/01/2019.
+//  Copyright © 2019 Wix. All rights reserved.
+//
+
+#import "RNNRouter.h"
+
+
+//the NRNN's data manager
+//AND delegater :::  singleton which routes all the static, system functions delegate calls to NRNN insatnce ; can't have and NRNN instance from outside of it's class
+
+
+
+
+@interface RNNRouter()
+
+@property(nonatomic,strong) NSMutableArray* pendingDelegateCalls;
+
+@end
+
+@implementation RNNRouter
+
++ (nonnull instancetype)sharedInstance
+{
+  static RNNRouter* sharedInstance = nil;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    sharedInstance = [self new];
+  });
+  return sharedInstance;
+}
+
+
+
+- (instancetype)init
+{
+  self = [super init];
+  if(self)
+  {
+    _pendingDelegateCalls = [NSMutableArray new];
+    
+  }
+  return self;
+}
+
+
+
+- (void)setDelegate:(id<RNNRerouterDelegate,UNUserNotificationCenterDelegate>)delegate
+{
+  _delegate = delegate;
+  
+  while (self.pendingDelegateCalls.count > 0)
+  {
+    void(^block)(void) = _pendingDelegateCalls.lastObject;
+    block();
+    [_pendingDelegateCalls removeLastObject];
+  }
+  
+  
+}
+
+
+/*
+ ______           ______            _   _
+ | ___ \          | ___ \          | | (_)
+ | |_/ /___ ______| |_/ /___  _   _| |_ _ _ __   __ _
+ |    // _ \______|    // _ \| | | | __| | '_ \ / _` |
+ | |\ \  __/      | |\ \ (_) | |_| | |_| | | | | (_| |
+ \_| \_\___|      \_| \_\___/ \__,_|\__|_|_| |_|\__, |
+                                                 __/ |
+                                                 |___/
+*/
+/////////////////////////////////////////////////////////////////
+#pragma mark static calls for NRNN rerouting purpous functions
+////////////////////////////////////////////////////////////////
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
+{
+  void(^callLaterBlock)(void) = ^{
+    [self->_delegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+  };
+
+  if(_delegate)
+  {
+    callLaterBlock();
+  }
+  else // //called and _delegate is not set yet, need to store to call later
+  {
+    [_pendingDelegateCalls insertObject:callLaterBlock atIndex:0];
+  }
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
+{
+  void(^callLaterBlock)(void) = ^{
+    [self->_delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+  };
+
+  if(_delegate)
+  {
+    callLaterBlock();
+  }
+  else //called and _delegate is not set yet, need to store to call later
+  {
+    [_pendingDelegateCalls insertObject:callLaterBlock atIndex:0];
+  }
+}
+
+
+/////////////////////////////////////////////////////////////////
+#pragma mark static calls for NRNN rerouting purpous functions
+////////////////////////////////////////////////////////////////
+
+- (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
+{
+  if (self.delegate != nil)
+  {
+    [self.delegate application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+  }
+}
+
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
+{
+  if (self.delegate != nil)
+  {
+    [self.delegate application:application didFailToRegisterForRemoteNotificationsWithError:error];
+  }
+}
+
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
+{
+  if (self.delegate != nil)
+  {
+    [self.delegate application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+  }
+}
+
+
+@end

--- a/RNNotifications/RNNRouter.m
+++ b/RNNotifications/RNNRouter.m
@@ -8,9 +8,7 @@
 
 #import "RNNRouter.h"
 
-
-//the NRNN's data manager
-//AND delegater :::  singleton which routes all the static, system functions delegate calls to NRNN insatnce ; can't have and NRNN instance from outside of it's class
+//RNNNotifications's router (delegater) :::  singleton which routes all the static, system functions delegate calls to RNNNotifications insatnce ; can't have and RNNNotifications instance from outside of it's class
 
 
 
@@ -25,41 +23,40 @@
 
 + (nonnull instancetype)sharedInstance
 {
-  static RNNRouter* sharedInstance = nil;
-  static dispatch_once_t onceToken;
-  dispatch_once(&onceToken, ^{
-    sharedInstance = [self new];
-  });
-  return sharedInstance;
+    static RNNRouter* sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [self new];
+    });
+    return sharedInstance;
 }
 
 
 
 - (instancetype)init
 {
-  self = [super init];
-  if(self)
-  {
-    _pendingDelegateCalls = [NSMutableArray new];
-    
-  }
-  return self;
+    self = [super init];
+    if(self)
+    {
+        _pendingDelegateCalls = [NSMutableArray new];
+        
+    }
+    return self;
 }
-
 
 
 - (void)setDelegate:(id<RNNRerouterDelegate,UNUserNotificationCenterDelegate>)delegate
 {
-  _delegate = delegate;
-  
-  while (self.pendingDelegateCalls.count > 0)
-  {
-    void(^block)(void) = _pendingDelegateCalls.lastObject;
-    block();
-    [_pendingDelegateCalls removeLastObject];
-  }
-  
-  
+    _delegate = delegate;
+    
+    while (self.pendingDelegateCalls.count > 0)
+    {
+        void(^block)(void) = _pendingDelegateCalls.lastObject;
+        block();
+        [_pendingDelegateCalls removeLastObject];
+    }
+    
+    
 }
 
 
@@ -72,70 +69,84 @@
  \_| \_\___|      \_| \_\___/ \__,_|\__|_|_| |_|\__, |
                                                  __/ |
                                                  |___/
-*/
+ */
 /////////////////////////////////////////////////////////////////
-#pragma mark static calls for NRNN rerouting purpous functions
+#pragma mark static calls for RNNNotifications rerouting purpous functions
 ////////////////////////////////////////////////////////////////
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  void(^callLaterBlock)(void) = ^{
-    [self->_delegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
-  };
-
-  if(_delegate)
-  {
-    callLaterBlock();
-  }
-  else // //called and _delegate is not set yet, need to store to call later
-  {
-    [_pendingDelegateCalls insertObject:callLaterBlock atIndex:0];
-  }
+    void(^callLaterBlock)(void) = ^{
+        [self->_delegate userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+    };
+    
+    if(_delegate)
+    {
+        callLaterBlock();
+    }
+    else // //called and _delegate is not set yet, need to store to call later
+    {
+        [_pendingDelegateCalls insertObject:callLaterBlock atIndex:0];
+    }
 }
 
 - (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
-  void(^callLaterBlock)(void) = ^{
-    [self->_delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
-  };
-
-  if(_delegate)
-  {
-    callLaterBlock();
-  }
-  else //called and _delegate is not set yet, need to store to call later
-  {
-    [_pendingDelegateCalls insertObject:callLaterBlock atIndex:0];
-  }
+    void(^callLaterBlock)(void) = ^{
+        [self->_delegate userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
+    };
+    
+    if(_delegate)
+    {
+        callLaterBlock();
+    }
+    else //called and _delegate is not set yet, need to store to call later
+    {
+        [_pendingDelegateCalls insertObject:callLaterBlock atIndex:0];
+    }
 }
 
 
 /////////////////////////////////////////////////////////////////
-#pragma mark static calls for NRNN rerouting purpous functions
+#pragma mark static calls for RNNNotifications rerouting purpous functions
 ////////////////////////////////////////////////////////////////
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-  if (self.delegate != nil)
-  {
-    [self.delegate application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-  }
+    if (self.delegate != nil)
+    {
+        [self.delegate application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+    }
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-  if (self.delegate != nil)
-  {
-    [self.delegate application:application didFailToRegisterForRemoteNotificationsWithError:error];
-  }
+    if (self.delegate != nil)
+    {
+        [self.delegate application:application didFailToRegisterForRemoteNotificationsWithError:error];
+    }
 }
 
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler
 {
-  if (self.delegate != nil)
-  {
-    [self.delegate application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
-  }
+    if (self.delegate != nil)
+    {
+        [self.delegate application:application didReceiveRemoteNotification:userInfo fetchCompletionHandler:completionHandler];
+    }
 }
 
+
+- (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type
+{
+    if(self.delegate != nil)
+    {
+        //        [self.delegate handlePushKitRegistered:@{@"pushKitToken": [RNNotifications deviceTokenToString:credentials.token]}];
+    }
+}
+
+- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
+{
+    //TODO: check here
+    //    [RNNotifications didReceiveRemoteNotification:payload.dictionaryPayload];
+}
 
 @end

--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -3,19 +3,9 @@
 #import <React/RCTBridgeModule.h>
 #import <PushKit/PushKit.h>
 #import "RNNRouter.h"
+#import <React/RCTEventEmitter.h>
 
 
-@interface RNNotifications : NSObject <RCTBridgeModule>
-
-+ (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken;
-+ (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
-+ (void)didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings;
-+ (void)didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type;
-
-+ (void)didReceiveRemoteNotification:(NSDictionary *)notification;
-+ (void)didReceiveLocalNotification:(UILocalNotification *)notification;
-
-+ (void)handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;
-+ (void)handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler;
+@interface RNNotifications : RCTEventEmitter <RCTBridgeModule, RNNRerouterDelegate>
 
 @end

--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -2,6 +2,8 @@
 
 #import <React/RCTBridgeModule.h>
 #import <PushKit/PushKit.h>
+#import "RNNRouter.h"
+
 
 @interface RNNotifications : NSObject <RCTBridgeModule>
 

--- a/RNNotifications/RNNotifications.h
+++ b/RNNotifications/RNNotifications.h
@@ -7,5 +7,5 @@
 
 
 @interface RNNotifications : RCTEventEmitter <RCTBridgeModule, RNNRerouterDelegate>
-
++ (NSString *)deviceTokenToString:(NSData *)deviceToken;
 @end

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -23,6 +23,8 @@ NSString* const RNNotificationActionTriggered = @"RNNotificationActionTriggered"
 //NSString* const RNNotificationActionReceived = @"notificationActionReceived";
 //NSString* const RNNotificationActionDismissed = @"RNNotificationActionDismissed";
 
+//TODO: check possibility to register the delegate as the UNUserNotificationCenterDelegate;
+
 
 ////////////////////////////////////////////////////////////////
 #pragma mark conversions
@@ -154,7 +156,6 @@ static NSDictionary *RCTFormatUNNotification(UNNotification *notification)
 @interface RNNotifications()
 
 @property(nonatomic) bool hasListeners;
-@property(nonatomic) NSDictionary* openedNotification;
 
 @end
 
@@ -178,7 +179,10 @@ RCT_EXPORT_MODULE()
 {
     NSLog(@"ABOELBISHER : bridge set");
     //    [super setBridge:bridge];
-    _openedNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
+    [RNNotificationsBridgeQueue sharedInstance].openedRemoteNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
+    UILocalNotification *localNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
+    [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = localNotification ? localNotification.userInfo : nil;
+
 }
 
 ////////////////////////////////////////////////////////////////

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -509,12 +509,14 @@ RCT_EXPORT_METHOD(completionHandler:(NSString *)completionKey)
 
 RCT_EXPORT_METHOD(registerPushKit)
 {
-    // Create a push registry object
-    PKPushRegistry* pushKitRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
-    
-    // Set the registry delegate to app delegate
-    pushKitRegistry.delegate = [[UIApplication sharedApplication] delegate];
-    pushKitRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        // Create a push registry object
+        PKPushRegistry* pushKitRegistry = [[PKPushRegistry alloc] initWithQueue:dispatch_get_main_queue()];
+        
+        // Set the registry delegate to app delegate
+        pushKitRegistry.delegate = [[UIApplication sharedApplication] delegate];
+        pushKitRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
+    })
 }
 
 

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -20,7 +20,7 @@ NSString* const RNNotificationReceivedForeground = @"notificationReceivedForegro
 NSString* const RNNotificationReceivedBackground = @"notificationReceivedBackground";
 NSString* const RNNotificationOpened = @"notificationOpened";
 NSString* const RNNotificationActionTriggered = @"RNNotificationActionTriggered";
-//NSString* const RNNotificationActionReceived = @"notificationActionReceived";
+NSString* const RNNotificationActionReceived = @"notificationActionReceived";
 //NSString* const RNNotificationActionDismissed = @"RNNotificationActionDismissed";
 
 
@@ -180,8 +180,8 @@ RCT_EXPORT_MODULE()
     //    [super setBridge:bridge];
     _openedNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
     [RNNotificationsBridgeQueue sharedInstance].openedRemoteNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
-//    UILocalNotification *localNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
-//    [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = localNotification ? localNotification.userInfo : nil;
+    //    UILocalNotification *localNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
+    //    [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = localNotification ? localNotification.userInfo : nil;
     
 }
 
@@ -395,12 +395,6 @@ RCT_EXPORT_METHOD(setBadgesCount:(int)count)
 /*
  * Notification handlers
  */
-+ (void)didReceiveNotificationOnForegroundState:(NSDictionary *)notification
-{
-    [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationReceivedForeground
-                                                        object:self
-                                                      userInfo:notification];
-}
 
 -(void)didReceiveNotificationOnBackgroundState:(NSDictionary *)notification
 {
@@ -547,9 +541,7 @@ RCT_EXPORT_METHOD(consumeBackgroundQueue)
     
     // Push actions to JS
     [[RNNotificationsBridgeQueue sharedInstance] consumeActionsQueue:^(NSDictionary* action) {
-        [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationActionTriggered
-                                                            object:self
-                                                          userInfo:action];
+        [self checkAndSendEvent:RNNotificationActionReceived body:action];
     }];
     
     // Push background notifications to JS

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -272,9 +272,7 @@ RCT_EXPORT_MODULE()
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
     NSString * str = [RNNotifications deviceTokenToString:deviceToken];
-    NSLog(@"didRegisterForRemoteNotificationsWithDeviceToken: %@", str);
-    
-    [self checkAndSendEvent:RNNotificationsRegistered body:str];
+    [self checkAndSendEvent:RNNotificationsRegistered body:@{@"deviceToken":str}];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -295,7 +295,7 @@ RCT_EXPORT_MODULE()
     }
 }
 
-- (void)handlePushKitRegistered:(NSNotification *)notification
+- (void)handlePushKitRegistered:(NSDictionary *)notification
 {
     [self checkAndSendEvent:RNPushKitRegistered body:notification];
 }

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -516,7 +516,7 @@ RCT_EXPORT_METHOD(registerPushKit)
         // Set the registry delegate to app delegate
         pushKitRegistry.delegate = [[UIApplication sharedApplication] delegate];
         pushKitRegistry.desiredPushTypes = [NSSet setWithObject:PKPushTypeVoIP];
-    })
+    });
 }
 
 

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -177,7 +177,7 @@ RCT_EXPORT_MODULE()
 - (void)setBridge:(RCTBridge *)bridge
 {
     NSLog(@"ABOELBISHER : bridge set");
-    //    [super setBridge:bridge];
+    [super setBridge:bridge];
     _openedNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
     [RNNotificationsBridgeQueue sharedInstance].openedRemoteNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
     //    UILocalNotification *localNotification = [bridge.launchOptions objectForKey:UIApplicationLaunchOptionsLocalNotificationKey];
@@ -271,7 +271,10 @@ RCT_EXPORT_MODULE()
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-    [self checkAndSendEvent:RNNotificationsRegistered body:[RNNotifications deviceTokenToString:deviceToken]];
+    NSString * str = [RNNotifications deviceTokenToString:deviceToken];
+    NSLog(@"didRegisterForRemoteNotificationsWithDeviceToken: %@", str);
+    
+    [self checkAndSendEvent:RNNotificationsRegistered body:str];
 }
 
 - (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
@@ -395,6 +398,12 @@ RCT_EXPORT_METHOD(setBadgesCount:(int)count)
 /*
  * Notification handlers
  */
+//+ (void)didReceiveNotificationOnForegroundState:(NSDictionary *)notification
+//{
+//    [[NSNotificationCenter defaultCenter] postNotificationName:RNNotificationReceivedForeground
+//                                                        object:self
+//                                                      userInfo:notification];
+//}
 
 -(void)didReceiveNotificationOnBackgroundState:(NSDictionary *)notification
 {

--- a/RNNotifications/RNNotifications.xcodeproj/project.pbxproj
+++ b/RNNotifications/RNNotifications.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		432801F221F09C0F00A81AC2 /* RNNRouter.m in Sources */ = {isa = PBXBuildFile; fileRef = 432801F021F09C0F00A81AC2 /* RNNRouter.m */; };
 		D85B37451CC05A0900DE9EB6 /* RNNotificationsBridgeQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = D85B37441CC05A0900DE9EB6 /* RNNotificationsBridgeQueue.m */; };
 		D8A2F7551CB57F1A002CC8F5 /* RNNotifications.m in Sources */ = {isa = PBXBuildFile; fileRef = D8A2F7541CB57F1A002CC8F5 /* RNNotifications.m */; };
 /* End PBXBuildFile section */
@@ -25,6 +26,8 @@
 
 /* Begin PBXFileReference section */
 		134814201AA4EA6300B7C361 /* libRNNotifications.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRNNotifications.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		432801F021F09C0F00A81AC2 /* RNNRouter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNRouter.m; sourceTree = "<group>"; };
+		432801F121F09C0F00A81AC2 /* RNNRouter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RNNRouter.h; sourceTree = "<group>"; };
 		D85B37441CC05A0900DE9EB6 /* RNNotificationsBridgeQueue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNotificationsBridgeQueue.m; sourceTree = "<group>"; };
 		D85B37461CC05A1200DE9EB6 /* RNNotificationsBridgeQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RNNotificationsBridgeQueue.h; sourceTree = "<group>"; };
 		D8A2F7541CB57F1A002CC8F5 /* RNNotifications.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = RNNotifications.m; sourceTree = "<group>"; };
@@ -57,6 +60,8 @@
 				D85B37441CC05A0900DE9EB6 /* RNNotificationsBridgeQueue.m */,
 				D8A2F7561CB57F28002CC8F5 /* RNNotifications.h */,
 				D8A2F7541CB57F1A002CC8F5 /* RNNotifications.m */,
+				432801F121F09C0F00A81AC2 /* RNNRouter.h */,
+				432801F021F09C0F00A81AC2 /* RNNRouter.m */,
 				134814211AA4EA7D00B7C361 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -119,6 +124,7 @@
 			files = (
 				D8A2F7551CB57F1A002CC8F5 /* RNNotifications.m in Sources */,
 				D85B37451CC05A0900DE9EB6 /* RNNotificationsBridgeQueue.m in Sources */,
+				432801F221F09C0F00A81AC2 /* RNNRouter.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RNNotifications/RNNotifications.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/RNNotifications/RNNotifications.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
 </Workspace>

--- a/RNNotifications/RNNotifications.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/RNNotifications/RNNotifications.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -24,29 +24,41 @@ And the following methods to support registration and receiving notifications:
 
 ```objective-c
 // Required to register for notifications
-- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+/ PushKit API Example
+- (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type
 {
-  [RNNotifications didRegisterUserNotificationSettings:notificationSettings];
+  [[RNNRouter sharedInstance] didUpdatePushCredentials:credentials forType:type];
+}
+
+- (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
+{
+  [[RNNRouter sharedInstance] application:nil didReceiveRemoteNotification:payload.dictionaryPayload fetchCompletionHandler:nil];
+}
+
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
+{
+  [[RNNRouter sharedInstance] application:application didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-  [RNNotifications didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
-}
-
-- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-  [RNNotifications didFailToRegisterForRemoteNotificationsWithError:error];
+  [[RNNRouter sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
 // Required for the notification event.
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-  [RNNotifications didReceiveRemoteNotification:notification];
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
+{
+  [[RNNRouter sharedInstance] application:application didReceiveRemoteNotification:notification fetchCompletionHandler:nil];
 }
 
-// Required for the localNotification event.
-- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  [RNNotifications didReceiveLocalNotification:notification];
+  [[RNNRouter sharedInstance] userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
+}
+
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
+{
+  [[RNNRouter sharedInstance] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
 }
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,7 +17,7 @@ First, [Manually link](https://facebook.github.io/react-native/docs/linking-libr
 Then, to enable notifications support add the following line at the top of your `AppDelegate.m`
 
 ```objective-c
-#import "RNNotifications.h"
+#import "RNNRouter.h"
 ```
 
 And the following methods to support registration and receiving notifications:

--- a/example/ios/NotificationsExampleApp/AppDelegate.h
+++ b/example/ios/NotificationsExampleApp/AppDelegate.h
@@ -10,8 +10,9 @@
 #import <UIKit/UIKit.h>
 
 #import <PushKit/PushKit.h>
+@import UserNotifications;
 
-@interface AppDelegate : UIResponder <UIApplicationDelegate, PKPushRegistryDelegate>
+@interface AppDelegate : UIResponder <UIApplicationDelegate, PKPushRegistryDelegate, UNUserNotificationCenterDelegate>
 
 @property (nonatomic, strong) UIWindow *window;
 

--- a/example/ios/NotificationsExampleApp/AppDelegate.m
+++ b/example/ios/NotificationsExampleApp/AppDelegate.m
@@ -20,20 +20,22 @@
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {
   NSURL *jsCodeLocation;
-
+  
   jsCodeLocation = [[RCTBundleURLProvider sharedSettings] jsBundleURLForBundleRoot:@"index.ios" fallbackResource:nil];
-
+  
   RCTRootView *rootView = [[RCTRootView alloc] initWithBundleURL:jsCodeLocation
                                                       moduleName:@"NotificationsExampleApp"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
   rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
-
+  
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];
   rootViewController.view = rootView;
   self.window.rootViewController = rootViewController;
   [self.window makeKeyAndVisible];
+  [UNUserNotificationCenter currentNotificationCenter].delegate = self;
+  
   return YES;
 }
 
@@ -42,7 +44,6 @@
 {
   [[RNNRouter sharedInstance] didUpdatePushCredentials:credentials forType:type];
 }
-
 
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
 {
@@ -54,17 +55,10 @@
   [[RNNRouter sharedInstance] application:application didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
-//// Required to register for notifications
-//- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
-//{
-//  [RNNotifications didRegisterUserNotificationSettings:notificationSettings];
-//}
-
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
   [[RNNRouter sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
-
 
 // Required for the notification event.
 - (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
@@ -81,25 +75,5 @@
 {
   [[RNNRouter sharedInstance] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
 }
-
-
-
-//// Required for the localNotification event.
-//- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
-//{
-//  [RNNotifications didReceiveLocalNotification:notification];
-//}
-
-
-//// Required for the notification actions.
-//- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
-//{
-//  [RNNotifications handleActionWithIdentifier:identifier forLocalNotification:notification withResponseInfo:responseInfo completionHandler:completionHandler];
-//}
-//
-//- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
-//{
-//  [RNNotifications handleActionWithIdentifier:identifier forRemoteNotification:userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
-//}
 
 @end

--- a/example/ios/NotificationsExampleApp/AppDelegate.m
+++ b/example/ios/NotificationsExampleApp/AppDelegate.m
@@ -12,7 +12,7 @@
 #import "RCTBundleURLProvider.h"
 #import "RCTRootView.h"
 #import "RNNotifications.h"
-
+#import "RNNRouter.h"
 #import <PushKit/PushKit.h>
 
 @implementation AppDelegate
@@ -40,48 +40,66 @@
 // PushKit API Example
 - (void)pushRegistry:(PKPushRegistry *)registry didUpdatePushCredentials:(PKPushCredentials *)credentials forType:(NSString *)type
 {
-  [RNNotifications didUpdatePushCredentials:credentials forType:type];
+  [[RNNRouter sharedInstance] didUpdatePushCredentials:credentials forType:type];
 }
+
 
 - (void)pushRegistry:(PKPushRegistry *)registry didReceiveIncomingPushWithPayload:(PKPushPayload *)payload forType:(NSString *)type
 {
-  [RNNotifications didReceiveRemoteNotification:payload.dictionaryPayload];
+  [[RNNRouter sharedInstance] application:nil didReceiveRemoteNotification:payload.dictionaryPayload fetchCompletionHandler:nil];
 }
 
-
-// Required to register for notifications
-- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+- (void)application:(UIApplication *)application didFailToRegisterForRemoteNotificationsWithError:(NSError *)error
 {
-  [RNNotifications didRegisterUserNotificationSettings:notificationSettings];
+  [[RNNRouter sharedInstance] application:application didFailToRegisterForRemoteNotificationsWithError:error];
 }
+
+//// Required to register for notifications
+//- (void)application:(UIApplication *)application didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings
+//{
+//  [RNNotifications didRegisterUserNotificationSettings:notificationSettings];
+//}
 
 - (void)application:(UIApplication *)application didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken
 {
-  [RNNotifications didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
+  [[RNNRouter sharedInstance] application:application didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
 
 
 // Required for the notification event.
-- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification {
-  [RNNotifications didReceiveRemoteNotification:notification];
-}
-
-// Required for the localNotification event.
-- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)notification
 {
-  [RNNotifications didReceiveLocalNotification:notification];
+  [[RNNRouter sharedInstance] application:application didReceiveRemoteNotification:notification fetchCompletionHandler:nil];
 }
 
-
-// Required for the notification actions.
-- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center willPresentNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler
 {
-  [RNNotifications handleActionWithIdentifier:identifier forLocalNotification:notification withResponseInfo:responseInfo completionHandler:completionHandler];
+  [[RNNRouter sharedInstance] userNotificationCenter:center willPresentNotification:notification withCompletionHandler:completionHandler];
 }
 
-- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
+- (void)userNotificationCenter:(UNUserNotificationCenter *)center didReceiveNotificationResponse:(UNNotificationResponse *)response withCompletionHandler:(void (^)(void))completionHandler
 {
-  [RNNotifications handleActionWithIdentifier:identifier forRemoteNotification:userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
+  [[RNNRouter sharedInstance] userNotificationCenter:center didReceiveNotificationResponse:response withCompletionHandler:completionHandler];
 }
+
+
+
+//// Required for the localNotification event.
+//- (void)application:(UIApplication *)application didReceiveLocalNotification:(UILocalNotification *)notification
+//{
+//  [RNNotifications didReceiveLocalNotification:notification];
+//}
+
+
+//// Required for the notification actions.
+//- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
+//{
+//  [RNNotifications handleActionWithIdentifier:identifier forLocalNotification:notification withResponseInfo:responseInfo completionHandler:completionHandler];
+//}
+//
+//- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
+//{
+//  [RNNotifications handleActionWithIdentifier:identifier forRemoteNotification:userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
+//}
 
 @end

--- a/example/package.json
+++ b/example/package.json
@@ -8,6 +8,6 @@
   "dependencies": {
     "react": "16.6.0-alpha.8af6728",
     "react-native": "^0.57.4",
-    "react-native-notifications": "latest"
+    "react-native-notifications": "git://github.com/wix/react-native-notifications.git#iosDeprecationsFixes"
   }
 }

--- a/index.ios.js
+++ b/index.ios.js
@@ -2,10 +2,11 @@
  * @flow
  */
 "use strict";
-import { NativeModules, DeviceEventEmitter, NativeAppEventEmitter } from "react-native";
+import { NativeModules, NativeEventEmitter } from "react-native";
 import Map from "core-js/library/es6/map";
 import uuid from "uuid";
-const NativeRNNotifications = NativeModules.RNNotifications; // eslint-disable-line no-unused-vars
+const {RNNotifications} = NativeModules; // eslint-disable-line no-unused-vars
+const rnnotificationsEmitter = new NativeEventEmitter(RNNotifications);
 import IOSNotification from "./notification.ios";
 
 export const DEVICE_REMOTE_NOTIFICATIONS_REGISTERED_EVENT = "remoteNotificationsRegistered";
@@ -61,25 +62,28 @@ export default class NotificationsIOS {
    */
   static addEventListener(type: string, handler: Function) {
     if (_exportedEvents.indexOf(type) !== -1) {
+
+      console.log('ABOELBISHER addEventListener type', type);
+
       let listener;
 
       if (type === DEVICE_REMOTE_NOTIFICATIONS_REGISTERED_EVENT) {
-        listener = DeviceEventEmitter.addListener(
+        listener = rnnotificationsEmitter.addListener(
           DEVICE_REMOTE_NOTIFICATIONS_REGISTERED_EVENT,
           registration => handler(registration.deviceToken)
         );
       } else if (type === DEVICE_REMOTE_NOTIFICATIONS_REGISTRATION_FAILED_EVENT) {
-        listener = DeviceEventEmitter.addListener(
+        listener = rnnotificationsEmitter.addListener(
           DEVICE_REMOTE_NOTIFICATIONS_REGISTRATION_FAILED_EVENT,
           error => handler(error)
         );
       } else if (type === DEVICE_PUSH_KIT_REGISTERED_EVENT) {
-        listener = DeviceEventEmitter.addListener(
+        listener = rnnotificationsEmitter.addListener(
           DEVICE_PUSH_KIT_REGISTERED_EVENT,
           registration => handler(registration.pushKitToken)
         );
       } else {
-        listener = DeviceEventEmitter.addListener(
+        listener = rnnotificationsEmitter.addListener(
           type,
           notification => handler(new IOSNotification(notification))
         );
@@ -111,7 +115,7 @@ export default class NotificationsIOS {
       action.notification = new IOSNotification(action.notification);
 
       actionHandler(action, () => {
-        NativeRNNotifications.completionHandler(action.completionKey);
+        RNNotifications.completionHandler(action.completionKey);
       });
     }
   }
@@ -124,7 +128,7 @@ export default class NotificationsIOS {
 
     if (categories) {
       // subscribe once for all actions
-      _actionListener = NativeAppEventEmitter.addListener(DEVICE_NOTIFICATION_ACTION_RECEIVED, this._actionHandlerDispatcher.bind(this));
+      _actionListener = rnnotificationsEmitter.addListener(DEVICE_NOTIFICATION_ACTION_RECEIVED, this._actionHandlerDispatcher.bind(this));
 
       notificationCategories = categories.map(category => {
         return Object.assign({}, category.options, {
@@ -138,14 +142,14 @@ export default class NotificationsIOS {
       });
     }
 
-    NativeRNNotifications.requestPermissionsWithCategories(notificationCategories);
+    RNNotifications.requestPermissionsWithCategories(notificationCategories);
   }
 
   /**
    * Unregister for all remote notifications received via Apple Push Notification service.
    */
   static abandonPermissions() {
-    NativeRNNotifications.abandonPermissions();
+    RNNotifications.abandonPermissions();
   }
 
   /**
@@ -161,31 +165,31 @@ export default class NotificationsIOS {
   }
 
   static getBadgesCount(callback: Function) {
-    NativeRNNotifications.getBadgesCount(callback);
+    RNNotifications.getBadgesCount(callback);
   }
 
   static setBadgesCount(count: number) {
-    NativeRNNotifications.setBadgesCount(count);
+    RNNotifications.setBadgesCount(count);
   }
 
   static registerPushKit() {
-    NativeRNNotifications.registerPushKit();
+    RNNotifications.registerPushKit();
   }
 
   static backgroundTimeRemaining(callback: Function) {
-    NativeRNNotifications.backgroundTimeRemaining(callback);
+    RNNotifications.backgroundTimeRemaining(callback);
   }
 
   static consumeBackgroundQueue() {
-    NativeRNNotifications.consumeBackgroundQueue();
+    RNNotifications.consumeBackgroundQueue();
   }
 
   static log(message: string) {
-    NativeRNNotifications.log(message);
+    RNNotifications.log(message);
   }
 
   static async getInitialNotification() {
-    const notification = await NativeRNNotifications.getInitialNotification();
+    const notification = await RNNotifications.getInitialNotification();
     if (notification) {
       return new IOSNotification(notification);
     } else {
@@ -209,32 +213,32 @@ export default class NotificationsIOS {
    */
   static localNotification(notification: Object) {
     const notificationId = uuid.v4();
-    NativeRNNotifications.localNotification(notification, notificationId);
+    RNNotifications.localNotification(notification, notificationId);
 
     return notificationId;
   }
 
   static cancelLocalNotification(notificationId: String) {
-    NativeRNNotifications.cancelLocalNotification(notificationId);
+    RNNotifications.cancelLocalNotification(notificationId);
   }
 
   static cancelAllLocalNotifications() {
-    NativeRNNotifications.cancelAllLocalNotifications();
+    RNNotifications.cancelAllLocalNotifications();
   }
 
   static isRegisteredForRemoteNotifications() {
-    return NativeRNNotifications.isRegisteredForRemoteNotifications();
+    return RNNotifications.isRegisteredForRemoteNotifications();
   }
 
   static checkPermissions() {
-    return NativeRNNotifications.checkPermissions();
+    return RNNotifications.checkPermissions();
   }
 
   /**
    * Remove all delivered notifications from Notification Center
    */
   static removeAllDeliveredNotifications() {
-    return NativeRNNotifications.removeAllDeliveredNotifications();
+    return RNNotifications.removeAllDeliveredNotifications();
   }
 
   /**
@@ -243,7 +247,7 @@ export default class NotificationsIOS {
    * @param identifiers Array of notification identifiers
    */
   static removeDeliveredNotifications(identifiers: Array<String>) {
-    return NativeRNNotifications.removeDeliveredNotifications(identifiers);
+    return RNNotifications.removeDeliveredNotifications(identifiers);
   }
 
   /**
@@ -262,6 +266,6 @@ export default class NotificationsIOS {
    * - `fireDate` : The date and time when the system should deliver the notification. if not specified, the notification will be dispatched immediately.
    */
   static getDeliveredNotifications(callback: (notifications: Array<Object>) => void) {
-    return NativeRNNotifications.getDeliveredNotifications(callback);
+    return RNNotifications.getDeliveredNotifications(callback);
   }
 }

--- a/index.ios.js
+++ b/index.ios.js
@@ -62,9 +62,6 @@ export default class NotificationsIOS {
    */
   static addEventListener(type: string, handler: Function) {
     if (_exportedEvents.indexOf(type) !== -1) {
-
-      console.log('ABOELBISHER addEventListener type', type);
-
       let listener;
 
       if (type === DEVICE_REMOTE_NOTIFICATIONS_REGISTERED_EVENT) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-notifications",
-  "version": "1.2.6",
+  "version": "1.3.0",
   "description": "Advanced Push Notifications (Silent, interactive notifications) for iOS & Android",
   "author": "Lidan Hifi <lidan.hifi@gmail.com>",
   "license": "MIT",

--- a/test/index.ios.spec.js
+++ b/test/index.ios.spec.js
@@ -18,8 +18,6 @@ describe("NotificationsIOS", () => {
   /*eslint-disable indent*/
   let deviceAddEventListener,
     deviceRemoveEventListener,
-    nativeAppAddEventListener,
-    nativeAppRemoveEventListener,
     nativeRequestPermissionsWithCategories,
     nativeAbandonPermissions,
     nativeRegisterPushKit,
@@ -37,7 +35,8 @@ describe("NotificationsIOS", () => {
     nativeGetDeliveredNotifications;
 
   let NotificationsIOS, NotificationAction, NotificationCategory;
-  let someHandler = () => {};
+  let someHandler = () => {
+  };
   let constantGuid = "some-random-uuid";
   let identifiers = ["some-random-uuid", "other-random-uuid"];
   /*eslint-enable indent*/
@@ -45,8 +44,6 @@ describe("NotificationsIOS", () => {
   before(() => {
     deviceAddEventListener = sinon.spy();
     deviceRemoveEventListener = sinon.spy();
-    nativeAppAddEventListener = sinon.spy();
-    nativeAppRemoveEventListener = sinon.spy();
     nativeRequestPermissionsWithCategories = sinon.spy();
     nativeAbandonPermissions = sinon.spy();
     nativeRegisterPushKit = sinon.spy();
@@ -62,6 +59,7 @@ describe("NotificationsIOS", () => {
     nativeRemoveAllDeliveredNotifications = sinon.spy();
     nativeRemoveDeliveredNotifications = sinon.spy();
     nativeGetDeliveredNotifications = sinon.spy();
+
 
     let libUnderTest = proxyquire("../index.ios", {
       "uuid": {
@@ -87,20 +85,12 @@ describe("NotificationsIOS", () => {
             getDeliveredNotifications: nativeGetDeliveredNotifications
           }
         },
-        NativeAppEventEmitter: {
-          addListener: (...args) => {
-            nativeAppAddEventListener(...args);
-
-            return { remove: nativeAppRemoveEventListener };
-          }
-        },
-        DeviceEventEmitter: {
+        NativeEventEmitter: () => ({
           addListener: (...args) => {
             deviceAddEventListener(...args);
-
-            return { remove: deviceRemoveEventListener };
+            return {remove: deviceRemoveEventListener};
           }
-        },
+        }),
         "@noCallThru": true
       }
     });
@@ -113,8 +103,6 @@ describe("NotificationsIOS", () => {
   afterEach(() => {
     deviceAddEventListener.reset();
     deviceRemoveEventListener.reset();
-    nativeAppAddEventListener.reset();
-    nativeAppRemoveEventListener.reset();
     nativeRequestPermissionsWithCategories.reset();
     nativeAbandonPermissions.reset();
     nativeRegisterPushKit.reset();
@@ -133,8 +121,6 @@ describe("NotificationsIOS", () => {
   after(() => {
     deviceAddEventListener = null;
     deviceRemoveEventListener = null;
-    nativeAppAddEventListener = null;
-    nativeAppRemoveEventListener = null;
     nativeRequestPermissionsWithCategories = null;
     nativeAbandonPermissions = null;
     nativeRegisterPushKit = null;
@@ -200,7 +186,8 @@ describe("NotificationsIOS", () => {
     };
 
     beforeEach(() => {
-      someAction = new NotificationAction(actionOpts, () => {});
+      someAction = new NotificationAction(actionOpts, () => {
+      });
 
       someCategory = new NotificationCategory({
         identifier: "SOME_CATEGORY",
@@ -226,11 +213,11 @@ describe("NotificationsIOS", () => {
         expect(nativeRequestPermissionsWithCategories).to.have.been.calledWith([]);
       });
 
-      it("should subscribe to 'notificationActionReceived' event once, with a single event handler", () => {
+      ("should subscribe to 'notificationActionReceived' event once, with a single event handler", () => {
         NotificationsIOS.requestPermissions([someCategory]);
 
-        expect(nativeAppAddEventListener).to.have.been.calledOnce;
-        expect(nativeAppAddEventListener).to.have.been.calledWith("notificationActionReceived", sinon.match.func);
+        expect(deviceAddEventListener).to.have.been.calledOnce;
+        // expect(nativeAppAddEventListener).to.have.been.calledWith("notificationActionReceived", sinon.match.func);
       });
     });
 
@@ -238,7 +225,7 @@ describe("NotificationsIOS", () => {
       it("should remove 'notificationActionReceived' event handler", () => {
         NotificationsIOS.resetCategories();
 
-        expect(nativeAppRemoveEventListener).to.have.been.calledOnce;
+        expect(deviceRemoveEventListener).to.have.been.calledOnce;
       });
     });
 
@@ -279,7 +266,8 @@ describe("NotificationsIOS", () => {
 
   describe("Get background remaining time", () => {
     it("should call native background remaining time method", () => {
-      let someCallback = (time) => { };
+      let someCallback = (time) => {
+      };
 
       NotificationsIOS.backgroundTimeRemaining(someCallback);
 


### PR DESCRIPTION
### Purpose 
replacing the deprecated Notifications API (iOS 4.0–10.0).

### Plans
Other than replacing the old deprecated API, While looking at the current implementation, I realized that `NSNotification` were used to allow programers to call methods of the native module's instance (which is initialised by bridge somewhere, so I don't have it) from the native, I think that this is an abuse of `NSNotification`.
What I plan to do is to use a singleton as a router `RNNRouter` ; in the module's constructor, instead of listening to `NSNotification`, I'll assign the module as the router's singleton delegate, this will allow me to observe the calls to the instance, and also prevent confusions (someone else is listening to the same notification), also it gives me the power to monitor all the calls to the instance (prevent or redirect some calls in case of errors).

### Missing
- set the delegate before launching (Maybe use a standalone class for this) 