### PR TITLE
Replace compile and testCompile with implementation and testImplement…

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,10 +21,10 @@ android {
 dependencies {
     // Google's GCM.
 //    compile 'com.google.android.gms:play-services-gcm:15.0.1'
-    compile "com.google.firebase:firebase-messaging:17.3.0"
-    compile 'com.facebook.react:react-native:+'
+    implementation "com.google.firebase:firebase-messaging:17.3.0"
+    implementation 'com.facebook.react:react-native:+'
 
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:2.+'
-    testCompile 'org.robolectric:robolectric:3.1.4'
+    testImplementation 'junit:junit:4.12'
+    testImplementation 'org.mockito:mockito-core:2.+'
+    testImplementation 'org.robolectric:robolectric:3.1.4'
 }


### PR DESCRIPTION
Compile and testCompile in Gradle build file is obsolete for long time. So, this pull request replaces them with implementation and testImplementation. @yogevbd Please check and merge. Thanks