### PR TITLE
Compatibility to Min SDK16

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,7 +5,7 @@ android {
     buildToolsVersion '28.0.3'
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 16
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -152,9 +152,9 @@ public class PushNotification implements IPushNotification {
                 .setContentText(mNotificationProps.getBody())
                 .setSmallIcon(mContext.getApplicationInfo().icon)
                 .setContentIntent(intent)
-                 .setDefaults(Notification.DEFAULT_ALL)
+                .setDefaults(Notification.DEFAULT_ALL)
                 .setAutoCancel(true);
-        
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
                                                                   CHANNEL_NAME,

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.v4.app.NotificationCompat;
 
 import com.facebook.react.bridge.ReactContext;
 import com.wix.reactnativenotifications.core.AppLaunchHelper;
@@ -141,19 +142,19 @@ public class PushNotification implements IPushNotification {
         return getNotificationBuilder(intent).build();
     }
 
-    protected Notification.Builder getNotificationBuilder(PendingIntent intent) {
+    protected NotificationCompat.Builder getNotificationBuilder(PendingIntent intent) {
 
         String CHANNEL_ID = "channel_01";
         String CHANNEL_NAME = "Channel Name";
 
-        final Notification.Builder notification = new Notification.Builder(mContext)
+        final NotificationCompat.Builder notification = new NotificationCompat.Builder(mContext, CHANNEL_ID)
                 .setContentTitle(mNotificationProps.getTitle())
                 .setContentText(mNotificationProps.getBody())
                 .setSmallIcon(mContext.getApplicationInfo().icon)
                 .setContentIntent(intent)
-                .setDefaults(Notification.DEFAULT_ALL)
+                 .setDefaults(Notification.DEFAULT_ALL)
                 .setAutoCancel(true);
-
+        
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID,
                                                                   CHANNEL_NAME,


### PR DESCRIPTION
This PR reduces the required minSDK from 19 to 16 and includes ~1250 more supported android devices.

The `NotificationCompat.Builder` class is used instead of `Notification.Builder` for building Notifications on all Android Versions. This might require changes of the coresponding types in the custom code applied in your application (just change the type) - this is exactly then the case when you reference `getNotificationBuilder` from this library. (Example see [here](https://github.com/demokratie-live/democracy-client/commit/de4cd0b0012fae75957169321aa8df313099544b))

This fixes https://github.com/wix/react-native-notifications/issues/263

See more:
- https://developer.android.com/reference/android/support/v4/app/NotificationCompat.Builder
- https://stackoverflow.com/questions/28001194/java-lang-nosuchmethoderror-android-app-notificationbuilder-setcolor