### PR TITLE
Do not publish .history folder to npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ example/
 test/
 RNNotifications/DerivedData
 node_modules/
+.history/
 
 .eslintrc
 *.yml


### PR DESCRIPTION
`.history` folder has been published to npm since the last few versions.

We do not need these files to be released, and with these files it brokes Flow.