### PR TITLE
fix: mis-emission of notification opened event

### DIFF
--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -226,7 +226,8 @@ RCT_EXPORT_MODULE()
         
         if (![RNNotificationsBridgeQueue sharedInstance].jsIsReady)
         {
-            [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = notification.request.content.userInfo;
+            // TODO: schedule emit foreground/background
+            // [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = notification.request.content.userInfo;
             return;
         }
         
@@ -300,12 +301,15 @@ RCT_EXPORT_MODULE()
     {
         case (int)UIApplicationStateActive:
             [self checkAndSendEvent:RNNotificationReceivedForeground body:userInfo];
+            break;
             
         case (int)UIApplicationStateInactive:
             [self checkAndSendEvent:RNNotificationOpened body:userInfo];
+            break;
             
         default:
             [self checkAndSendEvent:RNNotificationReceivedBackground body:userInfo];
+            break;
     }
 }
 


### PR DESCRIPTION
1. fall through in switch causes emission of multiple events
2. `willPresentNotification` corresponds to `notificationReceivedForeground`/`notificationReceivedBackground`, not to `openedLocalNotification`