### PR TITLE
Fix several issues related to notification actions, and updated docs

### DIFF
--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -262,10 +262,10 @@ RCT_EXPORT_MODULE()
     
     // If notification has a TextInput, add its text to our info
     if ([response isKindOfClass:[UNTextInputNotificationResponse class]]) {
-    NSString* text = ((UNTextInputNotificationResponse*)response).userText;//[response objectForKey:UIUserNotificationActionResponseTypedTextKey];
-    if (text != NULL) {
-        info[@"text"] = text;
-    }
+        NSString* text = ((UNTextInputNotificationResponse*)response).userText;//[response objectForKey:UIUserNotificationActionResponseTypedTextKey];
+        if (text != NULL) {
+            info[@"text"] = text;
+        }
     }
     
     // add notification custom data
@@ -277,7 +277,7 @@ RCT_EXPORT_MODULE()
     [[RNNotificationsBridgeQueue sharedInstance] postAction:info withCompletionKey:completionKey andCompletionHandler:completionHandler];
     
     if ([RNNotificationsBridgeQueue sharedInstance].jsIsReady == YES) {
-        [self checkAndSendEvent:RNNotificationActionTriggered body:info];
+        [self checkAndSendEvent:RNNotificationActionReceived body:info];
         completionHandler();
     } else {
         [RNNotificationsBridgeQueue sharedInstance].openedLocalNotification = info;
@@ -341,6 +341,7 @@ RCT_EXPORT_MODULE()
               RNNotificationsRegistrationFailed,
               RNNotificationReceivedForeground,
               RNNotificationReceivedBackground,
+              RNNotificationActionReceived,
               RNNotificationOpened];
     
 }

--- a/RNNotifications/RNNotifications.m
+++ b/RNNotifications/RNNotifications.m
@@ -591,7 +591,9 @@ RCT_EXPORT_METHOD(consumeBackgroundQueue)
 
 RCT_EXPORT_METHOD(cancelAllLocalNotifications)
 {
-    [RCTSharedApplication() cancelAllLocalNotifications];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [RCTSharedApplication() cancelAllLocalNotifications];
+    });
 }
 
 RCT_EXPORT_METHOD(isRegisteredForRemoteNotifications:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject)

--- a/docs/advancedIos.md
+++ b/docs/advancedIos.md
@@ -150,22 +150,7 @@ Notification **actions** allow the user to interact with a given notification.
 
 Notification **categories** allow you to group multiple actions together, and to connect the actions with the push notification itself.
 
-In order to support interactive notifications, firstly add the following methods to `appDelegate.m` file:
-
-```objective-c
-// Required for the notification actions.
-- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forLocalNotification:(UILocalNotification *)notification withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
-{
-  [RNNotifications handleActionWithIdentifier:identifier forLocalNotification:notification withResponseInfo:responseInfo completionHandler:completionHandler];
-}
-
-- (void)application:(UIApplication *)application handleActionWithIdentifier:(NSString *)identifier forRemoteNotification:(NSDictionary *)userInfo withResponseInfo:(NSDictionary *)responseInfo completionHandler:(void (^)())completionHandler
-{
-  [RNNotifications handleActionWithIdentifier:identifier forRemoteNotification:userInfo withResponseInfo:responseInfo completionHandler:completionHandler];
-}
-```
-
-Then, follow the basic workflow of adding interactive notifications to your app:
+Follow this workflow of adding interactive notifications to your app:
 
 1. Config the actions.
 2. Group actions together into categories.


### PR DESCRIPTION
This PR provides a fix for #316 #314 and makes Notification actions functional again. 

The following line was causing a crash on both pressing the notification itself, and pressing a standard notification Action (non -TextInput). 
`NSString* text = ((UNTextInputNotificationResponse*)response).userText;`

In addition I updated the readme to reflect the fact that `handleActionWithIdentifier` methods in appDelegate.m no longer seem to be required for notification actions.