### PR TITLE
Fix possible NPE when notification bundle verification fails

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -99,7 +99,9 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
         Log.d(LOGTAG, "Native method invocation: postLocalNotification");
         final Bundle notificationProps = Arguments.toBundle(notificationPropsMap);
         final IPushNotification pushNotification = PushNotification.get(getReactApplicationContext().getApplicationContext(), notificationProps);
-        pushNotification.onPostRequest(notificationId);
+        if (pushNotification != null) {
+            pushNotification.onPostRequest(notificationId);
+        }
     }
 
     @ReactMethod

--- a/android/src/main/java/com/wix/reactnativenotifications/gcm/FcmInstanceIdListenerService.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/gcm/FcmInstanceIdListenerService.java
@@ -26,7 +26,9 @@ public class FcmInstanceIdListenerService extends FirebaseMessagingService {
 
         try {
             final IPushNotification notification = PushNotification.get(getApplicationContext(), bundle);
-            notification.onReceived();
+            if (notification != null) {
+                notification.onReceived();
+            }
         } catch (IPushNotification.InvalidNotificationException e) {
             // A GCM message, yes - but not the kind we know how to work with.
             Log.v(LOGTAG, "GCM message handling aborted", e);


### PR DESCRIPTION
When the notification bundle verification introduced by commit 731cc93bd44d0d8e385491a59f6c2ff4ad81f74d
returns false, PushNotification.get returns null. This commit adds null checks to
invocations of that method.

I experienced application crashes while using the microG framework, which (currently) does not set the message ID in the notification intent.