### PR TITLE
fixes and improvements for local push

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/Defs.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/Defs.java
@@ -7,6 +7,7 @@ public interface Defs {
     String TOKEN_RECEIVED_EVENT_NAME = "remoteNotificationsRegistered";
 
     String NOTIFICATION_RECEIVED_EVENT_NAME = "notificationReceived";
+    String LOCAL_NOTIFICATION_RECEIVED_EVENT_NAME = "localNotificationReceived";
     String NOTIFICATION_RECEIVED_FOREGROUND_EVENT_NAME = "notificationReceivedInForeground";
     String NOTIFICATION_OPENED_EVENT_NAME = "notificationOpened";
 }

--- a/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -95,8 +95,9 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     }
 
     @ReactMethod
-    public void postLocalNotification(ReadableMap notificationPropsMap, int notificationId) {
+    public void postLocalNotification(ReadableMap notificationPropsMap) {
         Log.d(LOGTAG, "Native method invocation: postLocalNotification");
+        int notificationId = Integer.parseInt(notificationPropsMap.getString("google.message_id"));
         final Bundle notificationProps = Arguments.toBundle(notificationPropsMap);
         final IPushNotification pushNotification = PushNotification.get(getReactApplicationContext().getApplicationContext(), notificationProps);
         pushNotification.onPostRequest(notificationId);

--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -21,6 +21,7 @@ import com.wix.reactnativenotifications.core.ProxyService;
 
 import static com.wix.reactnativenotifications.Defs.NOTIFICATION_OPENED_EVENT_NAME;
 import static com.wix.reactnativenotifications.Defs.NOTIFICATION_RECEIVED_EVENT_NAME;
+import static com.wix.reactnativenotifications.Defs.LOCAL_NOTIFICATION_RECEIVED_EVENT_NAME;
 import static com.wix.reactnativenotifications.Defs.NOTIFICATION_RECEIVED_FOREGROUND_EVENT_NAME;
 
 public class PushNotification implements IPushNotification {
@@ -87,7 +88,9 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public int onPostRequest(Integer notificationId) {
-        return postNotification(notificationId);
+        int id = postNotification(notificationId);
+        notifyLocalReceivedToJS();
+        return id;
     }
 
     @Override
@@ -200,6 +203,10 @@ public class PushNotification implements IPushNotification {
 
     private void notifyReceivedToJS() {
         mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
+    }
+
+    private void notifyLocalReceivedToJS() {
+        mJsIOHelper.sendEventToJS(LOCAL_NOTIFICATION_RECEIVED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
     }
 
     private void notifiyReceivedForegroundNotificationToJS() {

--- a/index.android.js
+++ b/index.android.js
@@ -67,7 +67,7 @@ export class NotificationsAndroid {
 
   static localNotification(notification: Object) {
     const id = Math.random() * 100000000 | 0; // Bitwise-OR forces value onto a 32bit limit
-    notification["google.message_id"] = id + '';
+    notification["google.message_id"] = id + "";
     RNNotifications.postLocalNotification(notification);
     return id;
   }

--- a/index.android.js
+++ b/index.android.js
@@ -24,6 +24,10 @@ export class NotificationsAndroid {
     notificationReceivedListener = DeviceEventEmitter.addListener("notificationReceived", (notification) => listener(new NotificationAndroid(notification)));
   }
 
+  static setLocalNotificationReceivedListener(listener) {
+    notificationReceivedListener = DeviceEventEmitter.addListener("localNotificationReceived", (notification) => listener(new NotificationAndroid(notification)));
+  }
+
   static setNotificationReceivedInForegroundListener(listener) {
     notificationReceivedInForegroundListener = DeviceEventEmitter.addListener("notificationReceivedInForeground", (notification) => listener(new NotificationAndroid(notification)));
   }
@@ -63,12 +67,13 @@ export class NotificationsAndroid {
 
   static localNotification(notification: Object) {
     const id = Math.random() * 100000000 | 0; // Bitwise-OR forces value onto a 32bit limit
-    RNNotifications.postLocalNotification(notification, id);
+    notification["google.message_id"] = id + '';
+    RNNotifications.postLocalNotification(notification);
     return id;
   }
 
   static cancelLocalNotification(id) {
-    RNNotifications.cancelLocalNotification(id);
+    RNNotifications.cancelLocalNotification(parseInt(id));
   }
 }
 

--- a/test/index.android.spec.js
+++ b/test/index.android.spec.js
@@ -206,7 +206,7 @@ describe("Notifications-Android > ", () => {
 
       const id = libUnderTest.NotificationsAndroid.localNotification(notification);
       expect(id).to.not.be.undefined;
-      expect(postLocalNotificationStub).to.have.been.calledWith(notification, id);
+      expect(postLocalNotificationStub).to.have.been.calledWith(notification);
     });
 
     it("should be called with a unique ID", () => {


### PR DESCRIPTION
I faced 2 problems on android:
1) error on sending of local push
2) absence of js notifier about local notice

Fixes:
1) "google.message_id" is required by any push message. See function "verifyNotificationBundle". I added this param and moved generated id into it
2) added notifier "notifyLocalReceivedToJS"

As bonus:
- local notice's data will contain id, so it's easy to cancel it from js