### PR TITLE
Make Android Notification Accept ID Prop to allow Notifications updates

### DIFF
--- a/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/android/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -10,7 +10,7 @@ public class PushNotificationProps {
         mBundle = new Bundle();
     }
 
-    public PushNotificationProps(String title, String body) {
+    public PushNotificationProps(String title, String body,int id) {
         mBundle = new Bundle();
         mBundle.putString("title", title);
         mBundle.putString("body", body);
@@ -26,6 +26,10 @@ public class PushNotificationProps {
 
     public String getBody() {
         return mBundle.getString("body");
+    }
+
+    public String getId() {
+        return mBundle.getString("id");
     }
 
     public Bundle asBundle() {


### PR DESCRIPTION
Now you can create a notification and send id prop to it and this will be set as the notification id (Useful on updating notification content).

*Usage
```
    NotificationsAndroid.localNotification({
      id:"19878", //THIS **MUST** BE AN INTEGER
      title: "My Title",
      body: "Some Textx",
      extra: "data",
      "google.message_id": ""
    });
```
