### PR TITLE
Fixing white square icon and annotation error

### DIFF
--- a/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -156,7 +156,7 @@ public class PushNotification implements IPushNotification {
                 .setAutoCancel(true);
 
 
-             int resourceID = mContext.getResources().getIdentifier("notificationIcon", "drawable", mContext.getPackageName());
+             int resourceID = mContext.getResources().getIdentifier("notification_icon", "drawable", mContext.getPackageName());
                 if (resourceID != 0) {
                     notification.setSmallIcon(resourceID);
                 } else {

--- a/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -151,10 +151,17 @@ public class PushNotification implements IPushNotification {
         final Notification.Builder notification = new Notification.Builder(mContext)
                 .setContentTitle(mNotificationProps.getTitle())
                 .setContentText(mNotificationProps.getBody())
-                .setSmallIcon(mContext.getApplicationInfo().icon)
                 .setContentIntent(intent)
                 .setDefaults(Notification.DEFAULT_ALL)
                 .setAutoCancel(true);
+
+
+             int resourceID = mContext.getResources().getIdentifier("notificationIcon", "drawable", mContext.getPackageName());
+                if (resourceID != 0) {
+                    notification.setSmallIcon(resourceID);
+                } else {
+                    notification.setSmallIcon(mContext.getApplicationInfo().icon);
+                }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel channel = new NotificationChannel(CHANNEL_ID,

--- a/android/app/src/reactNative59/java/com/wix/reactnativenotifications/NotificationManagerCompatFacade.java
+++ b/android/app/src/reactNative59/java/com/wix/reactnativenotifications/NotificationManagerCompatFacade.java
@@ -2,7 +2,7 @@
 package com.wix.reactnativenotifications;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
+import android.support.annotation.NonNull;
 import android.support.v4.app.NotificationManagerCompat;
 
 public abstract class NotificationManagerCompatFacade {

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -187,7 +187,7 @@ To do so edit `android/build.gradle` and add:
 
 #### Step #6: Set your notification Icon.
 
-By default, the package will use your native application icon. If your icon is not notification friendly, you may have to set and use a different icon. To do this, create a notificationIcon.png and add it to your drawable folders. Once that is done add the following line to your AndroidManifest.xml
+By default, the package will use your native application icon. If your icon is not notification friendly, you may have to set and use a different icon. To do this, create a notification_icon.png and add it to your drawable folders. Once that is done add the following line to your AndroidManifest.xml
 
 ```diff
 +<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable notification_icon" />

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -190,6 +190,6 @@ To do so edit `android/build.gradle` and add:
 By default, the package will use your native application icon. If your icon is not notification friendly, you may have to set and use a different icon. To do this, create a notificationIcon.png and add it to your drawable folders. Once that is done add the following line to your AndroidManifest.xml
 
 ```diff
-+<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable notificationIcon" />
++<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable notification_icon" />
 ```
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -184,3 +184,12 @@ To do so edit `android/build.gradle` and add:
 ```
 
 **Note**: As more build variants come available in the future, you will need to adjust the list (`names.contains("reactNative59")`). This is why we recommend the first solution.
+
+#### Step #6: Set your notification Icon.
+
+By default, the package will use your native application icon. If your icon is not notification friendly, you may have to set and use a different icon. To do this, create a notificationIcon.png and add it to your drawable folders. Once that is done add the following line to your AndroidManifest.xml
+
+```diff
++<meta-data android:name="com.google.firebase.messaging.default_notification_icon" android:resource="@drawable notificationIcon" />
+```
+


### PR DESCRIPTION
At the moment, the package has an error under RN59 where the wrong annotation is being imported. This is causing my build to break and can only assume many others who have not upgraded to 60.

The package also has an issue where the app icon is a white square. This is because the notification builder is setting the small icon to be the same as the app icon and in most cases the app icon does not follow the same design requirements as the notification icon (White and Transparent only). My change here should be a non breaking change as it still supports the app icon being imported if a notification icon is not defined/provided.