### PR TITLE
Autogenerate changelog using github-release-notes

### DIFF
--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -7,6 +7,6 @@ action "Enforce PR label" {
   uses = "yogevbd/enforce-label-action@1.0.0"
   secrets = ["GITHUB_TOKEN"]
   env = {
-    VALID_LABELS = "bug,enhancement,feature"
+    VALID_LABELS = "bug,enhancement,feature,skip-changelog"
   }
 }

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,9 +1,9 @@
 workflow "Verify labels" {
   on = "pull_request"
-  resolves = "VerifyLabels"
+  resolves = "Enforce PR label"
 }
 
-action "VerifyLabels" {
+action "Enforce PR label" {
   uses = "yogevbd/enforce-label-action@1.0.0"
   secrets = ["GITHUB_TOKEN"]
   env = {

--- a/.grenrc.js
+++ b/.grenrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  template: {
+    commit: ({message, url, author, name}) => `- [${message}](${url}) - ${author ? `@${author}` : name}`,
+    issue: "- {{name}} [{{text}}]({{url}})",
+    label: "[**{{label}}**]",
+    noLabel: "closed",
+    group: "\n#### {{heading}}\n",
+    changelogTitle: "# Changelog\n\n",
+    release: "## {{release}} ({{date}})\n{{body}}",
+    releaseSeparator: "\n---\n\n"
+  },
+  groupBy: {
+    "Enhancements:": ["enhancement", "internal"],
+    "Bug Fixes:": ["bug"],
+    "Features": ["feature"]
+  },
+  ignoreIssuesWith: [
+    "skip-changelog"
+  ],
+  ignoreTagsWith: [
+    "snapshot"
+  ],
+  dataSource: "prs",
+  changelogFileName: "CHANGELOG.gren.md",
+  tags: "all",
+  override: true,
+  generate: true
+}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,8 @@
     "detox": "13.x.x",
     "jsc-android": "236355.x.x",
     "jest": "24.8.0",
-    "metro-react-native-babel-preset": "0.55.x"
+    "metro-react-native-babel-preset": "0.55.x",
+    "github-release-notes": "0.17.0"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -3,7 +3,7 @@ const exec = require('shell-utils').exec;
 const semver = require('semver');
 const fs = require('fs');
 const _ = require('lodash');
-const path = require('path');
+const grenrc = require('../.grenrc');
 
 // Workaround JS
 const isRelease = process.env.RELEASE_BUILD === 'true';
@@ -99,7 +99,7 @@ function tagAndPublish(newVersion) {
     exec.execSync(`git tag -a ${newVersion} -m "${newVersion}"`);
     exec.execSyncSilent(`git push deploy ${newVersion} || true`);
     if (isRelease) {
-      updatePackageJsonGit(newVersion);
+        updateGit(newVersion);
     }
 }
 
@@ -115,14 +115,24 @@ function readPackageJson() {
     return JSON.parse(fs.readFileSync(getPackageJsonPath()));
 }
 
-function updatePackageJsonGit(version) {
+function updateGit(version) {
     exec.execSync(`git checkout ${BRANCH}`);
+    updatePackageJson(version);
+    generateChangelog();
+    exec.execSync(`git commit -m "Update package.json version to ${version} and generate CHANGELOG.gren.md [ci skip]"`);
+    exec.execSync(`git push deploy ${BRANCH}`);
+}
+
+function updatePackageJson(version) {
     const packageJson = readPackageJson();
     packageJson.version = version;
     writePackageJson(packageJson);
     exec.execSync(`git add package.json`);
-    exec.execSync(`git commit -m"Update package.json version to ${version} [ci skip]"`);
-    exec.execSync(`git push deploy ${BRANCH}`);
+}
+
+function generateChangelog() {
+    exec.execSync('gren changelog');
+    exec.execSync(`git add ${grenrc.changelogFileName}`);
 }
 
 run();


### PR DESCRIPTION
Resolves and categorise PR's using labels and generates `CHANGELOG.gren.md` upon each release.