### PR TITLE
Fix source files location in podspec

### DIFF
--- a/react-native-notifications.podspec
+++ b/react-native-notifications.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '8.0'
 
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'notification.ios.js', 'notification.android.js', 'index.android.js', 'index.ios.js'
-  s.source_files   = 'RNNotifications/*.{h,m}'
+  s.source_files   = 'lib/ios/*.{h,m}'
 
   s.dependency 'React'
 end


### PR DESCRIPTION
After making this change locally I was able to compile without manually linking. I haven't run anything yet, but the build is succeeding and I'm pretty certain the path was quite outdated before this change so I thought it was worth pull requesting.