### PR TITLE
Wrap request call in a way that lets us use await

### DIFF
--- a/lib/src/index.ios.js
+++ b/lib/src/index.ios.js
@@ -136,6 +136,22 @@ export default class NotificationsIOS {
     NativeRNNotifications.requestPermissionsWithCategories(notificationCategories);
   }
 
+  static requestPermissionsAsync(categories: Array<NotificationCategory>) {
+    return new Promise((resolve, reject) => {
+      const onRegisterSuccess = deviceToken => {
+        resolve(deviceToken);
+        NotificationsIOS.removeEventListener('remoteNotificationsRegistered', onRegisterSuccess);
+      };
+      const onRegisterError = error => {
+        reject(error);
+        NotificationsIOS.removeEventListener('remoteNotificationsRegistered', onRegisterError);
+      };
+      NotificationsIOS.addEventListener('remoteNotificationsRegistered', onRegisterSuccess);
+      NotificationsIOS.addEventListener('remoteNotificationsRegistrationFailed', onRegisterError);
+      NotificationsIOS.requestPermissions(categories);
+    });
+  }
+
   /**
    * Unregister for all remote notifications received via Apple Push Notification service.
    */


### PR DESCRIPTION
Enables:
```
try {    
    const res = await notifications.requestPermissionAsync();  
    console.log("Resolved", res); 
} catch(error) {
    console.log("Rejected", error);
}
```

Good idea, bad idea? If it's something that sounds appealing let me know and I'll write tests and the android side of this