### PR TITLE
Indicated that local notifications are actually supported on Android

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,12 @@ _For information regarding proper integration with [react-native-navigation](htt
 ### Android
 
 - Receiving notifications in any App state (foreground, background, "dead")
+- Local notifications
 - Built-in notification drawer management
 - High degree of code extensibility to allow for advanced custom layouts and any specific notifications behavior as available by [Android's API](https://developer.android.com/training/notify-user/build-notification.html)
 - Android equivalent of React-Native's implementation of [`PushNotificationsIOS.getInitialNotification()`](https://facebook.github.io/react-native/docs/pushnotificationios.html#getinitialnotification).
 
-_Upcoming: local notifications, background-state Rx queue (iOS equivalent)_
+_Upcoming: background-state Rx queue (iOS equivalent)_
 
 
 # Quick Links


### PR DESCRIPTION
Apparently the README is a bit outdated.
https://github.com/wix/react-native-notifications/issues/413