### PR TITLE
package wix.reactnativenotifications does not exist

### DIFF
--- a/docs/installation-android.md
+++ b/docs/installation-android.md
@@ -13,12 +13,13 @@ import com.wix.reactnativenotifications.RNNotificationsPackage;
 
     @Override
     protected List<ReactPackage> getPackages() {
-        return Arrays.<ReactPackage>asList(
-            new MainReactPackage(),
-	        // ...
-	        // Add this line:
-	        new RNNotificationsPackage(MainApplication.this)
-        );
+       @SuppressWarnings("UnnecessaryLocalVariable")
+       List<ReactPackage> packages = new PackageList(this).getPackages();
+       // ... 
+       // Add the following line: 
+       packages.add(new RNNotificationsPackage(MainApplication.this)); 
+       return packages;
+    }
 ```
 
 ### Receiving push notifications
@@ -52,6 +53,7 @@ buildscript {
 ```gradle
 dependencies {
     ...
+    implementation project(':react-native-notifications')
     implementation 'com.google.firebase:firebase-core:16.0.0'
 }
 


### PR DESCRIPTION
Issue #461 

I got the following error message. 
package com.wix.reactnativenotifications does not exist

I fixed it by making the following changes. 

1. Added the following line to Project/app/build.gradle
implementation project(':react-native-notifications')

2. Changed the line in MainApplication.java FROM: 
new RNNotificationsPackage(MainApplication.this) 

TO: 
packages.add(new RNNotificationsPackage(MainApplication.this)); 
