### PR TITLE
Use resolve reject for getBadgeCount

### DIFF
--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -60,8 +60,8 @@ RCT_EXPORT_METHOD(registerPushKit) {
     [_commandsHandler registerPushKit];
 }
 
-RCT_EXPORT_METHOD(getBadgeCount:(RCTResponseSenderBlock)callback) {
-    [_commandsHandler getBadgeCount:callback];
+RCT_EXPORT_METHOD(getBadgeCount:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    [_commandsHandler getBadgeCount:resolve reject:reject];
 }
 
 RCT_EXPORT_METHOD(setBadgeCount:(int)count) {

--- a/lib/ios/RNCommandsHandler.h
+++ b/lib/ios/RNCommandsHandler.h
@@ -19,7 +19,7 @@
 
 - (void)registerPushKit;
 
-- (void)getBadgeCount:(RCTResponseSenderBlock)callback;
+- (void)getBadgeCount:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
 - (void)setBadgeCount:(int)count;
 

--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -41,9 +41,9 @@
     [RNNotifications startMonitorPushKitNotifications];
 }
 
-- (void)getBadgeCount:(RCTResponseSenderBlock)callback {
+- (void)getBadgeCount:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
     NSInteger count = [UIApplication sharedApplication].applicationIconBadgeNumber;
-    callback(@[ [NSNumber numberWithInteger:count] ]);
+    resolve([NSNumber numberWithInteger:count]);
 }
 
 - (void)setBadgeCount:(int)count {


### PR DESCRIPTION
I was getting a similar error message to https://github.com/wix/react-native-notifications/issues/429 but for `getBadgeCount()`. Turns out we need to use resolve and reject blocks as it is expected to return a promise.