### PR TITLE
Make NotificationIOS also work with flat object

### DIFF
--- a/lib/src/DTO/NotificationIOS.ts
+++ b/lib/src/DTO/NotificationIOS.ts
@@ -23,22 +23,37 @@ export class NotificationIOS extends Notification {
   }
 
   get title(): string {
+    if (!this.aps || !this.alert) {
+      return super.title;
+    }
     return this.alert.title;
   }
 
   get body(): string {
+    if (!this.aps || !this.alert) {
+      return super.body;
+    }
     return this.alert.body;
   }
 
   get sound(): string {
+    if (!this.aps) {
+      return super.sound;
+    }
     return this.aps.sound;
   }
 
   get badge(): number {
+    if (!this.aps) {
+      return super.badge;
+    }
     return this.aps.badge;
   }
 
   get thread(): string {
+    if (!this.aps) {
+      return super.thread;
+    }
     return this.aps.thread;
   }
 }


### PR DESCRIPTION
This addresses the issue in https://github.com/wix/react-native-notifications/issues/471 where NotificationIOS assumes `aps` and `alert` structure but native code returns local notification in a flat object.