### PR TITLE
Use JobIntentService over IntentService

### DIFF
--- a/lib/android/app/src/main/AndroidManifest.xml
+++ b/lib/android/app/src/main/AndroidManifest.xml
@@ -29,6 +29,7 @@
 
         <service
             android:name=".fcm.FcmInstanceIdRefreshHandlerService"
+            android:permission="android.permission.BIND_JOB_SERVICE"
             android:exported="false" />
     </application>
 

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -131,6 +131,6 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
         final Context appContext = getReactApplicationContext().getApplicationContext();
         final Intent tokenFetchIntent = new Intent(appContext, FcmInstanceIdRefreshHandlerService.class);
         tokenFetchIntent.putExtra(extraFlag, true);
-        appContext.startService(tokenFetchIntent);
+        FcmInstanceIdRefreshHandlerService.enqueueWork(appContext, tokenFetchIntent);
     }
 }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdRefreshHandlerService.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdRefreshHandlerService.java
@@ -1,19 +1,22 @@
 package com.wix.reactnativenotifications.fcm;
 
-import android.app.IntentService;
+import android.support.annotation.NonNull;
+import android.support.v4.app.JobIntentService;
+import android.content.Context;
 import android.content.Intent;
 
-public class FcmInstanceIdRefreshHandlerService extends IntentService {
+public class FcmInstanceIdRefreshHandlerService extends JobIntentService {
 
     public static String EXTRA_IS_APP_INIT = "isAppInit";
     public static String EXTRA_MANUAL_REFRESH = "doManualRefresh";
+    static final int JOB_ID = 1000;
 
-    public FcmInstanceIdRefreshHandlerService() {
-        super(FcmInstanceIdRefreshHandlerService.class.getSimpleName());
+    public static void enqueueWork(Context context, Intent work) {
+        enqueueWork(context, FcmInstanceIdRefreshHandlerService.class, JOB_ID, work);
     }
 
     @Override
-    protected void onHandleIntent(Intent intent) {
+    protected void onHandleWork(@NonNull Intent intent) {
         IFcmToken fcmToken = FcmToken.get(this);
         if (fcmToken == null) {
             return;


### PR DESCRIPTION
Maybe fixes https://github.com/wix/react-native-notifications/issues/217 ?

Because of [background service limitations](https://developer.android.com/about/versions/oreo/background.html#services) introduced in Android 8.0, functionality that relies on IntentService may not work properly. At Mattermost we starting seeing a high amount of the following exception:
```
com.facebook.react.common.JavascriptException: Error: Exception in HostObject::get(propName:WixRNNotifications): java.lang.IllegalStateException: Not allowed to start service Intent { cmp=com.mattermost.rn/com.wix.reactnativenotifications.gcm.FcmInstanceIdRefreshHandlerService (has extras) }:
```

While I wasn't able to reproduce, it seems that the IntentService is not playing nice with the background limitations mentioned above. We're applying these changes in a patch but I thought I'd open a PR here as well.