### PR TITLE
Fix initial notification data lost issue and empty foreground notification issue

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -4,28 +4,25 @@ import android.app.Activity;
 import android.app.Application;
 import android.content.Intent;
 import android.os.Bundle;
-import android.util.Log;
 
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
 import com.google.firebase.FirebaseApp;
 import com.wix.reactnativenotifications.core.AppLifecycleFacade;
 import com.wix.reactnativenotifications.core.AppLifecycleFacadeHolder;
+import com.wix.reactnativenotifications.core.InitialNotificationHolder;
 import com.wix.reactnativenotifications.core.NotificationIntentAdapter;
 import com.wix.reactnativenotifications.core.notification.IPushNotification;
 import com.wix.reactnativenotifications.core.notification.PushNotification;
+import com.wix.reactnativenotifications.core.notification.PushNotificationProps;
 import com.wix.reactnativenotifications.core.notificationdrawer.IPushNotificationsDrawer;
 import com.wix.reactnativenotifications.core.notificationdrawer.PushNotificationsDrawer;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-
-import static com.wix.reactnativenotifications.Defs.LOGTAG;
 
 public class RNNotificationsPackage implements ReactPackage, AppLifecycleFacade.AppVisibilityListener, Application.ActivityLifecycleCallbacks {
 
@@ -76,6 +73,13 @@ public class RNNotificationsPackage implements ReactPackage, AppLifecycleFacade.
 
     @Override
     public void onActivityStarted(Activity activity) {
+        Bundle bundle = activity.getIntent().getExtras();
+        if (bundle != null) {
+            PushNotificationProps props = new PushNotificationProps(bundle);
+            if (props.isFirebaseBackgroundPayload()) {
+                InitialNotificationHolder.getInstance().set(props);
+            }
+        }
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -11,15 +11,19 @@ public class PushNotificationProps {
     }
 
     public String getTitle() {
-        return mBundle.getString("title");
+        return getBundleStringFirstNotNull("gcm.notification.title", "title");
     }
 
     public String getBody() {
-        return mBundle.getString("body");
+        return getBundleStringFirstNotNull("gcm.notification.body", "body");
     }
 
     public Bundle asBundle() {
         return (Bundle) mBundle.clone();
+    }
+
+    public boolean isFirebaseBackgroundPayload() {
+        return mBundle.containsKey("google.message_id") && !mBundle.containsKey("title");
     }
 
     @Override
@@ -33,5 +37,10 @@ public class PushNotificationProps {
 
     protected PushNotificationProps copy() {
         return new PushNotificationProps((Bundle) mBundle.clone());
+    }
+
+    private String getBundleStringFirstNotNull(String key1, String key2) {
+        String result = mBundle.getString(key1);
+        return result == null ? mBundle.getString(key2) : result;
     }
 }


### PR DESCRIPTION
This PR fixes:
* Empty foreground notification content if your notification payload has `title` and `body` files under `notification` field rather than `data`.
* Get `undefined` initial notification data if your notification payload has `title` and `body` files under `notification` field rather than `data`.

Details of issue and notification payloads: https://github.com/wix/react-native-notifications/issues/456#issuecomment-585559278
Related issues: #456 , #492