### PR TITLE
Fix EventsRegistry.registerNotificationOpened typing

### DIFF
--- a/lib/src/adapters/CompletionCallbackWrapper.ts
+++ b/lib/src/adapters/CompletionCallbackWrapper.ts
@@ -36,8 +36,8 @@ export class CompletionCallbackWrapper {
     callback(notification, completion);
   }
 
-  public wrapOpenedCallback(callback: Function): (notification: Notification, completion: () => void, actionResponse?: NotificationActionResponse) => void {
-    return (notification, _completion, actionResponse) => {
+  public wrapOpenedCallback(callback: Function): (notification: Notification, actionResponse?: NotificationActionResponse) => void {
+    return (notification, actionResponse) => {
       const completion = () => {
         if (Platform.OS === 'ios') {
           this.nativeCommandsSender.finishHandlingAction((notification as unknown as NotificationIOS).identifier);

--- a/lib/src/adapters/NativeEventsReceiver.ts
+++ b/lib/src/adapters/NativeEventsReceiver.ts
@@ -1,6 +1,6 @@
 import { NativeModules, NativeEventEmitter, EventEmitter, EmitterSubscription } from 'react-native';
 import {
-  Registered, RegistrationError, RegisteredPushKit
+  Registered, RegistrationError, RegisteredPushKit, NotificationResponse
 } from '../interfaces/NotificationEvents';
 import { Notification } from '../DTO/Notification';
 import { NotificationActionResponse } from '../interfaces/NotificationActionResponse';
@@ -30,10 +30,10 @@ export class NativeEventsReceiver {
     return this.emitter.addListener('pushKitNotificationReceived', callback);
   }
 
-  public registerNotificationOpened(callback: (notification: Notification, completion: () => void, actionResponse?: NotificationActionResponse) => void): EmitterSubscription {
-    return this.emitter.addListener('notificationOpened', (response, completion) => {
-      const action = response.action ? new NotificationActionResponse(response.action) : undefined
-      callback(this.notificationFactory.fromPayload(response.notification), completion, action);
+  public registerNotificationOpened(callback: (notification: Notification, actionResponse?: NotificationActionResponse) => void): EmitterSubscription {
+    return this.emitter.addListener('notificationOpened', (response: NotificationResponse) => {
+      const action = response.action ? new NotificationActionResponse(response.action) : undefined;
+      callback(this.notificationFactory.fromPayload(response.notification), action);
     });
   }
 

--- a/lib/src/events/EventsRegistry.test.ts
+++ b/lib/src/events/EventsRegistry.test.ts
@@ -158,13 +158,17 @@ describe('EventsRegistry', () => {
     it('should wrap callback with completion block', () => {
       const wrappedCallback = jest.fn();
       const notification: Notification  = new Notification({identifier: 'identifier'});
-      const response: NotificationResponse = {notification, identifier: 'responseId'};
+      const response: NotificationResponse = {
+        notification,
+        identifier: 'responseId',
+        action: { identifier: 'actionIdentifier', text: 'userText' },
+      };
 
       uut.registerNotificationOpened(wrappedCallback);
       const call = mockNativeEventsReceiver.registerNotificationOpened.mock.calls[0][0];
-      call(response);
+      call(response.notification, response.action);
       
-      expect(wrappedCallback).toBeCalledWith(response, expect.any(Function), undefined); //JMC: ActionResponse
+      expect(wrappedCallback).toBeCalledWith(response.notification, expect.any(Function), response.action);
       expect(wrappedCallback).toBeCalledTimes(1);
     });
 


### PR DESCRIPTION
`EventsRegistry.registerNotificationOpened` registers a `callback` that expects a `response: NotificationResponse` object as the first parameter. In the registered callback, we can expect `response.notificaiton` to be the notification opened.
However, `NativeEventsReceiver.registerNotificationOpened` wants a `callback` that expects a `notification: Notification` object instead. So we are passing back `notification` as the `response` which will cause the callback code to get `undefined` as the notification.
This fixes the mismatch to supply both the notification and the action to the registered callback.