### PR TITLE
Use resolve reject for getDeliveredNotifications

### DIFF
--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -99,8 +99,8 @@ RCT_EXPORT_METHOD(removeDeliveredNotifications:(NSArray<NSString *> *)identifier
     [_commandsHandler removeDeliveredNotifications:identifiers];
 }
 
-RCT_EXPORT_METHOD(getDeliveredNotifications:(RCTResponseSenderBlock)callback) {
-    [_commandsHandler getDeliveredNotifications:callback];
+RCT_EXPORT_METHOD(getDeliveredNotifications:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject) {
+    [_commandsHandler getDeliveredNotifications:resolve reject:reject];
 }
 
 #endif

--- a/lib/ios/RNCommandsHandler.h
+++ b/lib/ios/RNCommandsHandler.h
@@ -39,6 +39,6 @@
 
 - (void)removeDeliveredNotifications:(NSArray<NSString *> *)identifiers;
 
-- (void)getDeliveredNotifications:(RCTResponseSenderBlock)callback;
+- (void)getDeliveredNotifications:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject;
 
 @end

--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -78,8 +78,8 @@
     [_notificationCenter removeDeliveredNotifications:identifiers];
 }
 
-- (void)getDeliveredNotifications:(RCTResponseSenderBlock)callback {
-    [_notificationCenter getDeliveredNotifications:callback];
+- (void)getDeliveredNotifications:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
+    [_notificationCenter getDeliveredNotifications:resolve];
 }
 
 @end

--- a/lib/ios/RNNotificationCenter.h
+++ b/lib/ios/RNNotificationCenter.h
@@ -24,7 +24,7 @@ typedef void (^RCTPromiseRejectBlock)(NSString *code, NSString *message, NSError
 
 - (void)removeDeliveredNotifications:(NSArray<NSString *> *)identifiers;
 
-- (void)getDeliveredNotifications:(RCTResponseSenderBlock)callback;
+- (void)getDeliveredNotifications:(RCTPromiseResolveBlock)resolve;
 
 - (void)cancelAllLocalNotifications;
 


### PR DESCRIPTION
Used resolve and reject blocks as it is expected to return a promise in `getDeliveredNotifications`. Solves #429 