### PR TITLE
Wrap all log statements inside debug flag

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -46,7 +46,7 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
 
     @Override
     public void initialize() {
-        Log.d(LOGTAG, "Native module init");
+        if(BuildConfig.DEBUG) Log.d(LOGTAG, "Native module init");
         startFcmIntentService(FcmInstanceIdRefreshHandlerService.EXTRA_IS_APP_INIT);
 
         final IPushNotificationsDrawer notificationsDrawer = PushNotificationsDrawer.get(getReactApplicationContext().getApplicationContext());
@@ -71,13 +71,13 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
 
     @ReactMethod
     public void refreshToken() {
-        Log.d(LOGTAG, "Native method invocation: refreshToken()");
+        if(BuildConfig.DEBUG) Log.d(LOGTAG, "Native method invocation: refreshToken()");
         startFcmIntentService(FcmInstanceIdRefreshHandlerService.EXTRA_MANUAL_REFRESH);
     }
 
     @ReactMethod
     public void getInitialNotification(final Promise promise) {
-        Log.d(LOGTAG, "Native method invocation: getInitialNotification");
+        if(BuildConfig.DEBUG) Log.d(LOGTAG, "Native method invocation: getInitialNotification");
         Object result = null;
 
         try {
@@ -94,7 +94,7 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
 
     @ReactMethod
     public void postLocalNotification(ReadableMap notificationPropsMap, int notificationId) {
-        Log.d(LOGTAG, "Native method invocation: postLocalNotification");
+        if(BuildConfig.DEBUG) Log.d(LOGTAG, "Native method invocation: postLocalNotification");
         final Bundle notificationProps = Arguments.toBundle(notificationPropsMap);
         final IPushNotification pushNotification = PushNotification.get(getReactApplicationContext().getApplicationContext(), notificationProps);
         pushNotification.onPostRequest(notificationId);

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/AppLaunchHelper.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/AppLaunchHelper.java
@@ -5,6 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import com.wix.reactnativenotifications.BuildConfig;
+
 public class AppLaunchHelper {
     private static final String TAG = AppLaunchHelper.class.getSimpleName();
 
@@ -27,7 +29,7 @@ public class AppLaunchHelper {
             return intent;
         } catch (ClassNotFoundException e) {
             // Note: this is an imaginary scenario cause we're asking for a class of our very own package.
-            Log.e(TAG, "Failed to launch/resume app", e);
+            if(BuildConfig.DEBUG) Log.e(TAG, "Failed to launch/resume app", e);
             return null;
         }
     }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ProxyService.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ProxyService.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.util.Log;
 
+import com.wix.reactnativenotifications.BuildConfig;
 import com.wix.reactnativenotifications.core.notification.IPushNotification;
 import com.wix.reactnativenotifications.core.notification.PushNotification;
 
@@ -18,7 +19,7 @@ public class ProxyService extends IntentService {
 
     @Override
     protected void onHandleIntent(Intent intent) {
-        Log.d(TAG, "New intent: "+intent);
+        if (BuildConfig.DEBUG) Log.d(TAG, "New intent: "+intent);
         final Bundle notificationData = NotificationIntentAdapter.extractPendingNotificationDataFromIntent(intent);
         final IPushNotification pushNotification = PushNotification.get(this, notificationData);
         if (pushNotification != null) {

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
@@ -4,6 +4,7 @@ import android.util.Log;
 
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
+import com.wix.reactnativenotifications.BuildConfig;
 
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
@@ -21,19 +22,19 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
         reactContext.addLifecycleEventListener(new LifecycleEventListener() {
             @Override
             public void onHostResume() {
-                Log.d(LOGTAG, "onHostResume");
+                if(BuildConfig.DEBUG) Log.d(LOGTAG, "onHostResume");
                 switchToVisible();
             }
 
             @Override
             public void onHostPause() {
-                Log.d(LOGTAG, "onHostPause");
+                if(BuildConfig.DEBUG) Log.d(LOGTAG, "onHostPause");
                 switchToInvisible();
             }
 
             @Override
             public void onHostDestroy() {
-                Log.d(LOGTAG, "onHostDestroy");
+                if(BuildConfig.DEBUG) Log.d(LOGTAG, "onHostDestroy");
                 switchToInvisible();
             }
         });
@@ -75,7 +76,7 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
 
     private synchronized void switchToVisible() {
         if (!mIsVisible) {
-            Log.d(LOGTAG, "App is now visible");
+            if(BuildConfig.DEBUG) Log.d(LOGTAG, "App is now visible");
             mIsVisible = true;
             for (AppVisibilityListener listener : mListeners) {
                 listener.onAppVisible();
@@ -85,7 +86,7 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
 
     private synchronized void switchToInvisible() {
         if (mIsVisible) {
-            Log.d(LOGTAG, "App is now not visible");
+            if(BuildConfig.DEBUG) Log.d(LOGTAG, "App is now not visible");
             mIsVisible = false;
             for (AppVisibilityListener listener : mListeners) {
                 listener.onAppNotVisible();

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdListenerService.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdListenerService.java
@@ -5,6 +5,7 @@ import android.util.Log;
 
 import com.google.firebase.messaging.FirebaseMessagingService;
 import com.google.firebase.messaging.RemoteMessage;
+import com.wix.reactnativenotifications.BuildConfig;
 import com.wix.reactnativenotifications.core.notification.IPushNotification;
 import com.wix.reactnativenotifications.core.notification.PushNotification;
 
@@ -20,14 +21,14 @@ public class FcmInstanceIdListenerService extends FirebaseMessagingService {
     @Override
     public void onMessageReceived(RemoteMessage message){
         Bundle bundle = message.toIntent().getExtras();
-        Log.d(LOGTAG, "New message from FCM: " + bundle);
+        if(BuildConfig.DEBUG) Log.d(LOGTAG, "New message from FCM: " + bundle);
 
         try {
             final IPushNotification notification = PushNotification.get(getApplicationContext(), bundle);
             notification.onReceived();
         } catch (IPushNotification.InvalidNotificationException e) {
             // An FCM message, yes - but not the kind we know how to work with.
-            Log.v(LOGTAG, "FCM message handling aborted", e);
+            if(BuildConfig.DEBUG) Log.v(LOGTAG, "FCM message handling aborted", e);
         }
     }
 }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmToken.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmToken.java
@@ -11,6 +11,7 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.google.firebase.iid.InstanceIdResult;
+import com.wix.reactnativenotifications.BuildConfig;
 import com.wix.reactnativenotifications.core.JsIOHelper;
 
 import static com.wix.reactnativenotifications.Defs.LOGTAG;
@@ -50,10 +51,10 @@ public class FcmToken implements IFcmToken {
     public void onManualRefresh() {
         synchronized (mAppContext) {
             if (sToken == null) {
-                Log.i(LOGTAG, "Manual token refresh => asking for new token");
+                if(BuildConfig.DEBUG) Log.i(LOGTAG, "Manual token refresh => asking for new token");
                 refreshToken();
             } else {
-                Log.i(LOGTAG, "Manual token refresh => publishing existing token ("+sToken+")");
+                if(BuildConfig.DEBUG) Log.i(LOGTAG, "Manual token refresh => publishing existing token ("+sToken+")");
                 sendTokenToJS();
             }
         }
@@ -63,11 +64,11 @@ public class FcmToken implements IFcmToken {
     public void onAppReady() {
         synchronized (mAppContext) {
             if (sToken == null) {
-                Log.i(LOGTAG, "App initialized => asking for new token");
+                if(BuildConfig.DEBUG) Log.i(LOGTAG, "App initialized => asking for new token");
                 refreshToken();
             } else {
                 // Except for first run, this should be the case.
-                Log.i(LOGTAG, "App initialized => publishing existing token ("+sToken+")");
+                if(BuildConfig.DEBUG) Log.i(LOGTAG, "App initialized => publishing existing token ("+sToken+")");
                 sendTokenToJS();
             }
         }
@@ -78,7 +79,7 @@ public class FcmToken implements IFcmToken {
             @Override
             public void onSuccess(InstanceIdResult instanceIdResult) {
                 sToken = instanceIdResult.getToken();
-                Log.i(LOGTAG, "FCM has a new token" + "=" + sToken);
+                if(BuildConfig.DEBUG) Log.i(LOGTAG, "FCM has a new token" + "=" + sToken);
                 sendTokenToJS();
             }
         });


### PR DESCRIPTION
- We need to make sure that no log statements goes production since this
library deals with sensitive push device token.
- The method used is how android source code uses to log in debug
and remove logs in production.
- Tested in my app

Comment if you want me to make any changes in this PR