### PR TITLE
Remove obsolete elements from manifest

### DIFF
--- a/lib/android/app/src/main/AndroidManifest.xml
+++ b/lib/android/app/src/main/AndroidManifest.xml
@@ -3,15 +3,6 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.wix.reactnativenotifications">
 
-    <!--
-     Permissions required for enabling FCM.
-     -->
-    <permission
-        android:name="${applicationId}.permission.C2D_MESSAGE"
-        android:protectionLevel="signature" />
-    <uses-permission android:name="${applicationId}.permission.C2D_MESSAGE" />
-    <uses-permission android:name="android.permission.VIBRATE" />
-
     <application>
 
         <!--


### PR DESCRIPTION
According to Google GCM to FCM Migration guide, the removed lines of code are no longer required. And could create duplicate notifications.
https://developers.google.com/cloud-messaging/android/android-migrate-fcm

I have run the library in my local project after removing those lines, it works fine.

I had already sent a PR which got closed due to inactivity by bot.
https://github.com/wix/react-native-notifications/pull/294

I hope at least this PR gets merged.

Please comment if you want me to make any changes in this PR.

Thanks