### PR TITLE
Update installation-ios.html

### DIFF
--- a/docs/installation-ios.html
+++ b/docs/installation-ios.html
@@ -93,7 +93,7 @@ target 'YourApp' do
   pod 'glog', :podspec =&gt; '../node_modules/react-native/third-party-podspecs/glog.podspec'
   pod 'Folly', :podspec =&gt; '../node_modules/react-native/third-party-podspecs/Folly.podspec'
 
-<span class="hljs-addition">+ pod 'ReactNativeNotifications', :podspec =&gt; '../node_modules/react-native-notifications/ReactNativeNotifications.podspec'</span>
+<span class="hljs-addition">+ pod 'ReactNativeNotifications', :podspec =&gt; '../node_modules/react-native-notifications'</span>
 
   use_native_modules!
 end


### PR DESCRIPTION
`pod install` will throw an error that ReactNativeNotifications.podspec is not found