### PR TITLE
Fix auto-link for android

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -2,7 +2,10 @@ module.exports = {
   dependency: {
     platforms: {
       ios: {},
-      android: {}
+      android: {
+        sourceDir: './lib/android/app',
+        packageInstance: 'new RNNotificationsPackage(reactNativeHost.getApplication())',
+      }
     },
     assets: []
   },


### PR DESCRIPTION
Currently, auto-link failing for android.

`react-native config` outputs followings.

```json
"react-native-notifications": {
  "root": "path_to/node_modules/react-native-notifications",
  "name": "react-native-notifications",
  "platforms": {
    "ios": {
      // ...
    },
    "android": null
  },
}
```

This commit fix this