### PR TITLE
fix: do not clear other notifications on open a notification

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -68,7 +68,6 @@ public class PushNotification implements IPushNotification {
     @Override
     public void onOpened() {
         digestNotification();
-        clearAllNotifications();
     }
 
     @Override
@@ -193,11 +192,6 @@ public class PushNotification implements IPushNotification {
     protected void postNotification(int id, Notification notification) {
         final NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.notify(id, notification);
-    }
-
-    protected void clearAllNotifications() {
-        final NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.cancelAll();
     }
 
     protected int createNotificationId(Notification notification) {

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawer.java
@@ -31,12 +31,10 @@ public class PushNotificationsDrawer implements IPushNotificationsDrawer {
 
     @Override
     public void onAppInit() {
-        clearAll();
     }
 
     @Override
     public void onAppVisible() {
-        clearAll();
     }
 
     @Override
@@ -45,7 +43,6 @@ public class PushNotificationsDrawer implements IPushNotificationsDrawer {
 
     @Override
     public void onNotificationOpened() {
-        clearAll();
     }
 
     @Override
@@ -62,11 +59,6 @@ public class PushNotificationsDrawer implements IPushNotificationsDrawer {
 
     @Override
     public void onAllNotificationsClearRequest() {
-        final NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
-        notificationManager.cancelAll();
-    }
-
-    protected void clearAll() {
         final NotificationManager notificationManager = (NotificationManager) mContext.getSystemService(Context.NOTIFICATION_SERVICE);
         notificationManager.cancelAll();
     }

--- a/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notification/PushNotificationTest.java
+++ b/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notification/PushNotificationTest.java
@@ -179,7 +179,7 @@ public class PushNotificationTest {
         final PushNotification uut = createUUT();
         uut.onOpened();
 
-        verify(mNotificationManager).cancelAll();
+        verify(mNotificationManager, never()).cancelAll();
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawerTest.java
+++ b/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawerTest.java
@@ -40,15 +40,21 @@ public class PushNotificationsDrawerTest {
     }
 
     @Test
-    public void onAppInit_clearAllNotifications() throws Exception {
+    public void onAppInit_neverClearAllNotifications() throws Exception {
         createUUT().onAppInit();
-        verify(mNotificationManager).cancelAll();
+        verify(mNotificationManager, never()).cancelAll();
     }
 
     @Test
-    public void onAppVisible_clearAllNotifications() throws Exception {
+    public void onAppVisible_neverClearAllNotifications() throws Exception {
         createUUT().onAppVisible();
-        verify(mNotificationManager).cancelAll();
+        verify(mNotificationManager, never()).cancelAll();
+    }
+
+    @Test
+    public void onNotificationOpened_neverClearAllNotifications() throws Exception {
+        createUUT().onNotificationOpened()
+        verify(mNotificationManager, never()).cancelAll();
     }
 
     @Test

--- a/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawerTest.java
+++ b/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notificationdrawer/PushNotificationsDrawerTest.java
@@ -53,7 +53,7 @@ public class PushNotificationsDrawerTest {
 
     @Test
     public void onNotificationOpened_neverClearAllNotifications() throws Exception {
-        createUUT().onNotificationOpened()
+        createUUT().onNotificationOpened();
         verify(mNotificationManager, never()).cancelAll();
     }
 


### PR DESCRIPTION
It fixes a problem of removing all notification from a notification drawer when a single notification is opened.