### PR TITLE
Add didReceiveSilentNotification to handle silent notifications

### DIFF
--- a/lib/ios/RCTConvert+RNNotifications.h
+++ b/lib/ios/RCTConvert+RNNotifications.h
@@ -20,3 +20,7 @@
 @interface RCTConvert (UNNotificationPresentationOptions)
 + (UNNotificationPresentationOptions)UNNotificationPresentationOptions:(id)json;
 @end
+
+@interface RCTConvert (NSDictionary)
++ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo;
+@end

--- a/lib/ios/RCTConvert+RNNotifications.m
+++ b/lib/ios/RCTConvert+RNNotifications.m
@@ -117,6 +117,14 @@
 
 @end
 
+@implementation RCTConvert (NSDictionary)
++ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo {
+    NSMutableDictionary *formattedNotification = [NSMutableDictionary dictionary];
+    [formattedNotification addEntriesFromDictionary:[NSDictionary dictionaryWithDictionary:RCTNullIfNil(RCTJSONClean(userInfo))]];
+    return formattedNotification;
+}
+@end
+
 @implementation RCTConvert (UNNotificationPresentationOptions)
 
 + (UNNotificationPresentationOptions)UNNotificationPresentationOptions:(id)json {

--- a/lib/ios/RNNotificationEventHandler.h
+++ b/lib/ios/RNNotificationEventHandler.h
@@ -12,5 +12,6 @@
 
 - (void)didReceiveForegroundNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
 - (void)didReceiveNotificationResponse:(UNNotificationResponse *)notificationResponse completionHandler:(void (^)(void))completionHandler;
+- (void)didReceiveSilentNotification:(NSDictionary *)userInfo;
 
 @end

--- a/lib/ios/RNNotificationEventHandler.m
+++ b/lib/ios/RNNotificationEventHandler.m
@@ -33,4 +33,8 @@
     [RNEventEmitter sendEvent:RNNotificationOpened body:[RNNotificationParser parseNotificationResponse:response]];
 }
 
+- (void)didReceiveSilentNotification:(NSDictionary *)userInfo {
+    [RNEventEmitter sendEvent:RNNotificationReceived body:[RNNotificationParser parseNotificationUserInfo:userInfo]];
+}
+
 @end

--- a/lib/ios/RNNotificationParser.h
+++ b/lib/ios/RNNotificationParser.h
@@ -5,5 +5,6 @@
 
 + (NSDictionary *)parseNotificationResponse:(UNNotificationResponse *)response;
 + (NSDictionary *)parseNotification:(UNNotification *)notification;
++ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo;
 
 @end

--- a/lib/ios/RNNotificationParser.m
+++ b/lib/ios/RNNotificationParser.m
@@ -7,6 +7,10 @@
     return [RCTConvert UNNotificationPayload:notification];
 }
 
++ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo {
+    return [RCTConvert NotificationUserInfo:userInfo];
+}
+
 + (NSDictionary *)parseNotificationResponse:(UNNotificationResponse *)response {
     NSDictionary* responseDict = @{@"notification": [RCTConvert UNNotificationPayload:response.notification], @"identifier": response.notification.request.identifier, @"action": [self parseNotificationResponseAction:response]};
     

--- a/lib/ios/RNNotifications.h
+++ b/lib/ios/RNNotifications.h
@@ -9,6 +9,8 @@
 + (void)startMonitorNotifications;
 + (void)startMonitorPushKitNotifications;
 
++ (void)didReceiveSilentNotification:(NSDictionary *)userInfo;
+
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken;
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 

--- a/lib/ios/RNNotifications.m
+++ b/lib/ios/RNNotifications.m
@@ -39,6 +39,10 @@
     [[self sharedInstance] startMonitorPushKitNotifications];
 }
 
++ (void)didReceiveSilentNotification:(NSDictionary *)userInfo {
+    [[self sharedInstance] didReceiveSilentNotification:userInfo];
+}
+
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken {
     [[self sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
@@ -67,6 +71,10 @@
 - (void)startMonitorPushKitNotifications {
     _pushKitEventHandler = [RNPushKitEventHandler new];
     _pushKit = [[RNPushKit alloc] initWithEventHandler:_pushKitEventHandler];
+}
+
+- (void)didReceiveSilentNotification:(NSDictionary *)userInfo {
+    [_notificationEventHandler didReceiveSilentNotification:userInfo];
 }
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken {


### PR DESCRIPTION
We still need to use `application:didReceiveRemoteNotification:fetchCompletionHandler:` to handle silent notifications / background updates according to [this](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app?language=objc).

I am adding this helper so I can simply call `[RNNotifications didReceiveSilentNotification]` in my `application:didReceiveRemoteNotification:fetchCompletionHandler:`.