### PR TITLE
Add event and handler for iOS background notification

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -36,6 +36,14 @@ class NotificationsExampleApp extends Component {
 
       completion();
     });
+
+    Notifications.events().registerNotificationReceivedBackground((notification, completion) => {
+      this.setState({
+        notifications: [...this.state.notifications, notification]
+      });
+
+      completion();
+    });
   }
 
   requestPermissions() {

--- a/example/ios/NotificationsExampleApp/AppDelegate.m
+++ b/example/ios/NotificationsExampleApp/AppDelegate.m
@@ -38,4 +38,8 @@
   [RNNotifications didFailToRegisterForRemoteNotificationsWithError:error];
 }
 
+- (void)application:(UIApplication *)application didReceiveRemoteNotification:(NSDictionary *)userInfo fetchCompletionHandler:(void (^)(UIBackgroundFetchResult result))completionHandler {
+  [RNNotifications didReceiveBackgroundNotification:userInfo withCompletionHandler:completionHandler];
+}
+
 @end

--- a/lib/ios/RCTConvert+RNNotifications.h
+++ b/lib/ios/RCTConvert+RNNotifications.h
@@ -20,3 +20,11 @@
 @interface RCTConvert (UNNotificationPresentationOptions)
 + (UNNotificationPresentationOptions)UNNotificationPresentationOptions:(id)json;
 @end
+
+@interface RCTConvert (UIBackgroundFetchResult)
++ (UIBackgroundFetchResult)UIBackgroundFetchResult:(NSString *)result;
+@end
+
+@interface RCTConvert (NSDictionary)
++ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier;
+@end

--- a/lib/ios/RCTConvert+RNNotifications.m
+++ b/lib/ios/RCTConvert+RNNotifications.m
@@ -117,6 +117,15 @@
 
 @end
 
+@implementation RCTConvert (NSDictionary)
++ (NSDictionary *)NotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier {
+    NSMutableDictionary *formattedNotification = [NSMutableDictionary dictionary];
+    formattedNotification[@"identifier"] = identifier;
+    [formattedNotification addEntriesFromDictionary:[NSDictionary dictionaryWithDictionary:RCTNullIfNil(RCTJSONClean(userInfo))]];
+    return formattedNotification;
+}
+@end
+
 @implementation RCTConvert (UNNotificationPresentationOptions)
 
 + (UNNotificationPresentationOptions)UNNotificationPresentationOptions:(id)json {
@@ -132,6 +141,20 @@
     }
     
     return options;
+}
+
+@end
+
+@implementation RCTConvert (UIBackgroundFetchResult)
+
++ (UIBackgroundFetchResult)UIBackgroundFetchResult:(NSString *)backgroundFetchResult {
+    UIBackgroundFetchResult result = UIBackgroundFetchResultNoData;
+    if ([@"newData" isEqualToString:backgroundFetchResult]) {
+        result = UIBackgroundFetchResultNewData;
+    } else if ([@"failed" isEqualToString:backgroundFetchResult]) {
+        result = UIBackgroundFetchResultFailed;
+    }
+    return result;
 }
 
 @end

--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -52,6 +52,10 @@ RCT_EXPORT_METHOD(finishPresentingNotification:(NSString *)completionKey present
     [_commandsHandler finishPresentingNotification:completionKey presentingOptions:presentingOptions];
 }
 
+RCT_EXPORT_METHOD(finishHandlingBackgroundAction:(NSString *)completionKey backgroundFetchResult:(NSString *)backgroundFetchResult) {
+    [_commandsHandler finishHandlingBackgroundAction:completionKey backgroundFetchResult:backgroundFetchResult];
+}
+
 RCT_EXPORT_METHOD(abandonPermissions) {
     [_commandsHandler abandonPermissions];
 }

--- a/lib/ios/RNCommandsHandler.h
+++ b/lib/ios/RNCommandsHandler.h
@@ -15,6 +15,8 @@
 
 - (void)finishPresentingNotification:(NSString *)completionKey presentingOptions:(NSDictionary *)presentingOptions;
 
+- (void)finishHandlingBackgroundAction:(NSString *)completionKey backgroundFetchResult:(NSString *)backgroundFetchResult;
+
 - (void)abandonPermissions;
 
 - (void)registerPushKit;

--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -33,6 +33,10 @@
     [[RNNotificationsStore sharedInstance] completePresentation:completionKey withPresentationOptions:[RCTConvert UNNotificationPresentationOptions:presentingOptions]];
 }
 
+- (void)finishHandlingBackgroundAction:(NSString *)completionKey backgroundFetchResult:(NSString *)backgroundFetchResult {
+    [[RNNotificationsStore sharedInstance] completeBackgroundAction:completionKey withBackgroundFetchResult:[RCTConvert UIBackgroundFetchResult:backgroundFetchResult]];
+}
+
 - (void)abandonPermissions {
     [[UIApplication sharedApplication] unregisterForRemoteNotifications];
 }

--- a/lib/ios/RNEventEmitter.h
+++ b/lib/ios/RNEventEmitter.h
@@ -4,6 +4,7 @@ static NSString* const RNRegistered                  = @"remoteNotificationsRegi
 static NSString* const RNRegistrationFailed          = @"remoteNotificationsRegistrationFailed";
 static NSString* const RNPushKitRegistered           = @"pushKitRegistered";
 static NSString* const RNNotificationReceived        = @"notificationReceived";
+static NSString* const RNNotificationReceivedBackground = @"notificationReceivedBackground";
 static NSString* const RNNotificationOpened          = @"notificationOpened";
 static NSString* const RNPushKitNotificationReceived = @"pushKitNotificationReceived";
 

--- a/lib/ios/RNEventEmitter.m
+++ b/lib/ios/RNEventEmitter.m
@@ -9,6 +9,7 @@ RCT_EXPORT_MODULE();
              RNRegistrationFailed,
              RNPushKitRegistered,
              RNNotificationReceived,
+             RNNotificationReceivedBackground,
              RNNotificationOpened,
              RNPushKitNotificationReceived];
 }

--- a/lib/ios/RNNotificationEventHandler.h
+++ b/lib/ios/RNNotificationEventHandler.h
@@ -12,5 +12,6 @@
 
 - (void)didReceiveForegroundNotification:(UNNotification *)notification withCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler;
 - (void)didReceiveNotificationResponse:(UNNotificationResponse *)notificationResponse completionHandler:(void (^)(void))completionHandler;
+- (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
 
 @end

--- a/lib/ios/RNNotificationEventHandler.m
+++ b/lib/ios/RNNotificationEventHandler.m
@@ -33,4 +33,10 @@
     [RNEventEmitter sendEvent:RNNotificationOpened body:[RNNotificationParser parseNotificationResponse:response]];
 }
 
+- (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    NSString *uuid = [[NSUUID UUID] UUIDString];
+    [_store setBackgroundActionCompletionHandler:completionHandler withCompletionKey:uuid];
+    [RNEventEmitter sendEvent:RNNotificationReceivedBackground body:[RNNotificationParser parseNotificationUserInfo:userInfo withIdentifier:uuid]];
+}
+
 @end

--- a/lib/ios/RNNotificationEventHandler.m
+++ b/lib/ios/RNNotificationEventHandler.m
@@ -35,8 +35,21 @@
 
 - (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     NSString *uuid = [[NSUUID UUID] UUIDString];
-    [_store setBackgroundActionCompletionHandler:completionHandler withCompletionKey:uuid];
-    [RNEventEmitter sendEvent:RNNotificationReceivedBackground body:[RNNotificationParser parseNotificationUserInfo:userInfo withIdentifier:uuid]];
+    __block BOOL completionHandlerCalled = NO;
+    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
+    [_store setBackgroundActionCompletionHandler:^(UIBackgroundFetchResult result) {
+      completionHandler(result);
+      completionHandlerCalled = YES;
+      dispatch_semaphore_signal(semaphore);
+    } withCompletionKey:uuid];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+      [RNEventEmitter sendEvent:RNNotificationReceivedBackground body:[RNNotificationParser parseNotificationUserInfo:userInfo withIdentifier:uuid]];
+    });
+    // Allow 25 seconds for this to process. If not finished call the callback with failed.
+    dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 25 * NSEC_PER_SEC));
+    if (!completionHandlerCalled) {
+      completionHandler(UIBackgroundFetchResultFailed);
+    }
 }
 
 @end

--- a/lib/ios/RNNotificationParser.h
+++ b/lib/ios/RNNotificationParser.h
@@ -5,5 +5,6 @@
 
 + (NSDictionary *)parseNotificationResponse:(UNNotificationResponse *)response;
 + (NSDictionary *)parseNotification:(UNNotification *)notification;
++ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier;
 
 @end

--- a/lib/ios/RNNotificationParser.m
+++ b/lib/ios/RNNotificationParser.m
@@ -7,6 +7,10 @@
     return [RCTConvert UNNotificationPayload:notification];
 }
 
++ (NSDictionary *)parseNotificationUserInfo:(NSDictionary *)userInfo withIdentifier:(NSString *)identifier {
+    return [RCTConvert NotificationUserInfo:userInfo withIdentifier:(NSString *)identifier];
+}
+
 + (NSDictionary *)parseNotificationResponse:(UNNotificationResponse *)response {
     NSDictionary* responseDict = @{@"notification": [RCTConvert UNNotificationPayload:response.notification], @"identifier": response.notification.request.identifier, @"action": [self parseNotificationResponseAction:response]};
     

--- a/lib/ios/RNNotifications.h
+++ b/lib/ios/RNNotifications.h
@@ -9,6 +9,8 @@
 + (void)startMonitorNotifications;
 + (void)startMonitorPushKitNotifications;
 
++ (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler;
+
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken;
 + (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error;
 

--- a/lib/ios/RNNotifications.m
+++ b/lib/ios/RNNotifications.m
@@ -39,6 +39,10 @@
     [[self sharedInstance] startMonitorPushKitNotifications];
 }
 
++ (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    [[self sharedInstance] didReceiveBackgroundNotification:userInfo withCompletionHandler:completionHandler];
+}
+
 + (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken {
     [[self sharedInstance] didRegisterForRemoteNotificationsWithDeviceToken:deviceToken];
 }
@@ -67,6 +71,10 @@
 - (void)startMonitorPushKitNotifications {
     _pushKitEventHandler = [RNPushKitEventHandler new];
     _pushKit = [[RNPushKit alloc] initWithEventHandler:_pushKitEventHandler];
+}
+
+- (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
+    [_notificationEventHandler didReceiveBackgroundNotification:userInfo withCompletionHandler:completionHandler];
 }
 
 - (void)didRegisterForRemoteNotificationsWithDeviceToken:(id)deviceToken {

--- a/lib/ios/RNNotificationsStore.h
+++ b/lib/ios/RNNotificationsStore.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 @import UserNotifications;
 
 @interface RNNotificationsStore : NSObject

--- a/lib/ios/RNNotificationsStore.h
+++ b/lib/ios/RNNotificationsStore.h
@@ -9,8 +9,10 @@
 
 - (void)completeAction:(NSString *)completionKey;
 - (void)completePresentation:(NSString *)completionKey withPresentationOptions:(UNNotificationPresentationOptions)presentationOptions;
+- (void)completeBackgroundAction:(NSString *)completionKey withBackgroundFetchResult:(UIBackgroundFetchResult)backgroundFetchResult;
 - (void)setActionCompletionHandler:(void (^)(void))completionHandler withCompletionKey:(NSString *)completionKey;
 - (void)setPresentationCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler withCompletionKey:(NSString *)completionKey;
+- (void)setBackgroundActionCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler withCompletionKey:(NSString *)completionKey;
 
 - (void (^)(void))getActionCompletionHandler:(NSString *)key;
 - (void (^)(UNNotificationPresentationOptions))getPresentationCompletionHandler:(NSString *)key;

--- a/lib/ios/RNNotificationsStore.m
+++ b/lib/ios/RNNotificationsStore.m
@@ -3,6 +3,7 @@
 @implementation RNNotificationsStore
 NSMutableDictionary* _actionCompletionHandlers;
 NSMutableDictionary* _presentationCompletionHandlers;
+NSMutableDictionary* _backgroundActionCompletionHandlers;
 
 + (instancetype)sharedInstance {
     static RNNotificationsStore *sharedInstance = nil;
@@ -18,6 +19,7 @@ NSMutableDictionary* _presentationCompletionHandlers;
     self = [super init];
     _actionCompletionHandlers = [NSMutableDictionary new];
     _presentationCompletionHandlers = [NSMutableDictionary new];
+    _backgroundActionCompletionHandlers = [NSMutableDictionary new];
     return self;
 }
 
@@ -27,6 +29,10 @@ NSMutableDictionary* _presentationCompletionHandlers;
 
 - (void)setPresentationCompletionHandler:(void (^)(UNNotificationPresentationOptions))completionHandler withCompletionKey:(NSString *)completionKey {
     _presentationCompletionHandlers[completionKey] = completionHandler;
+}
+
+- (void)setBackgroundActionCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler withCompletionKey:(NSString *)completionKey {
+    _backgroundActionCompletionHandlers[completionKey] = completionHandler;
 }
 
 - (void (^)(void))getActionCompletionHandler:(NSString *)key {
@@ -50,6 +56,14 @@ NSMutableDictionary* _presentationCompletionHandlers;
     if (completionHandler) {
         completionHandler(presentationOptions);
         [_presentationCompletionHandlers removeObjectForKey:completionKey];
+    }
+}
+
+- (void)completeBackgroundAction:(NSString *)completionKey withBackgroundFetchResult:(UIBackgroundFetchResult)backgroundFetchResult {
+    void (^completionHandler)() = (void (^)(UIBackgroundFetchResult))[_backgroundActionCompletionHandlers valueForKey:completionKey];
+    if (completionHandler) {
+        completionHandler(backgroundFetchResult);
+        [_backgroundActionCompletionHandlers removeObjectForKey:completionKey];
     }
 }
 

--- a/lib/src/adapters/CompletionCallbackWrapper.ts
+++ b/lib/src/adapters/CompletionCallbackWrapper.ts
@@ -1,5 +1,5 @@
 import { NativeCommandsSender } from './NativeCommandsSender';
-import { NotificationCompletion } from '../interfaces/NotificationCompletion';
+import { NotificationCompletion, NotificationBackgroundFetchResult } from '../interfaces/NotificationCompletion';
 import { Platform, AppState } from 'react-native';
 import {NotificationIOS} from "../DTO/NotificationIOS";
 import {Notification} from "..";
@@ -13,7 +13,7 @@ export class CompletionCallbackWrapper {
   public wrapReceivedBackgroundCallback(callback: Function): (notification: Notification) => void {
     return (notification) => {
       if (!this.applicationIsVisible()) {
-        this.wrapReceivedAndInvoke(callback, notification);
+        this.wrapReceivedAndInvoke(callback, notification, true);
       }
     }
   }
@@ -21,15 +21,20 @@ export class CompletionCallbackWrapper {
   public wrapReceivedForegroundCallback(callback: Function): (notification: Notification) => void {
     return (notification) => {
       if (this.applicationIsVisible()) {
-        this.wrapReceivedAndInvoke(callback, notification);
+        this.wrapReceivedAndInvoke(callback, notification, false);
       }
     }
   }
 
-  private wrapReceivedAndInvoke(callback: Function, notification: Notification) {
-    const completion = (response: NotificationCompletion) => {
+  private wrapReceivedAndInvoke(callback: Function, notification: Notification, background: boolean) {
+    const completion = (response: NotificationCompletion | NotificationBackgroundFetchResult) => {
       if (Platform.OS === 'ios') {
-        this.nativeCommandsSender.finishPresentingNotification((notification as unknown as NotificationIOS).identifier, response);
+        const identifier = (notification as unknown as NotificationIOS).identifier;
+        if (background) {
+          this.nativeCommandsSender.finishHandlingBackgroundAction(identifier, response as NotificationBackgroundFetchResult);
+        } else {
+          this.nativeCommandsSender.finishPresentingNotification(identifier, response as NotificationCompletion);
+        }
       }
     };
 

--- a/lib/src/adapters/CompletionCallbackWrapper.ts
+++ b/lib/src/adapters/CompletionCallbackWrapper.ts
@@ -1,6 +1,6 @@
 import { NativeCommandsSender } from './NativeCommandsSender';
 import { NotificationCompletion, NotificationBackgroundFetchResult } from '../interfaces/NotificationCompletion';
-import { Platform, AppState } from 'react-native';
+import { Platform } from 'react-native';
 import {NotificationIOS} from "../DTO/NotificationIOS";
 import {Notification} from "..";
 import { NotificationActionResponse } from '../interfaces/NotificationActionResponse';
@@ -12,17 +12,13 @@ export class CompletionCallbackWrapper {
 
   public wrapReceivedBackgroundCallback(callback: Function): (notification: Notification) => void {
     return (notification) => {
-      if (!this.applicationIsVisible()) {
-        this.wrapReceivedAndInvoke(callback, notification, true);
-      }
+      this.wrapReceivedAndInvoke(callback, notification, true);
     }
   }
 
   public wrapReceivedForegroundCallback(callback: Function): (notification: Notification) => void {
     return (notification) => {
-      if (this.applicationIsVisible()) {
-        this.wrapReceivedAndInvoke(callback, notification, false);
-      }
+      this.wrapReceivedAndInvoke(callback, notification, false);
     }
   }
 
@@ -51,9 +47,5 @@ export class CompletionCallbackWrapper {
 
       callback(notification, completion, actionResponse);
     }
-  }
-
-  private applicationIsVisible(): Boolean {
-    return AppState.currentState !== 'background';
   }
 }

--- a/lib/src/adapters/NativeCommandsSender.ts
+++ b/lib/src/adapters/NativeCommandsSender.ts
@@ -25,6 +25,7 @@ interface NativeCommandsModule {
   finishPresentingNotification(notificationId: string, callback: NotificationCompletion): void;
   finishHandlingAction(notificationId: string): void;
   setNotificationChannel(notificationChannel: NotificationChannel): void;
+  finishHandlingBackgroundAction(notificationId: string, backgroundFetchResult: string): void;
 }
 
 export class NativeCommandsSender {
@@ -107,5 +108,9 @@ export class NativeCommandsSender {
 
   setNotificationChannel(notificationChannel: NotificationChannel) {
     this.nativeCommandsModule.setNotificationChannel(notificationChannel);
+  }
+
+  finishHandlingBackgroundAction(notificationId: string, backgroundFetchResult: string): void {
+    this.nativeCommandsModule.finishHandlingBackgroundAction(notificationId, backgroundFetchResult);
   }
 }

--- a/lib/src/adapters/NativeEventsReceiver.ts
+++ b/lib/src/adapters/NativeEventsReceiver.ts
@@ -26,6 +26,12 @@ export class NativeEventsReceiver {
     });
   }
 
+  public registerNotificationReceivedBackground(callback: (notification: Notification) => void): EmitterSubscription {
+    return this.emitter.addListener('notificationReceivedBackground', (payload) => {
+      callback(this.notificationFactory.fromPayload(payload));
+    });
+  }
+
   public registerPushKitNotificationReceived(callback: (event: object) => void): EmitterSubscription {
     return this.emitter.addListener('pushKitNotificationReceived', callback);
   }

--- a/lib/src/events/EventsRegistry.test.ts
+++ b/lib/src/events/EventsRegistry.test.ts
@@ -5,7 +5,7 @@ import { CompletionCallbackWrapper } from '../adapters/CompletionCallbackWrapper
 import { NativeCommandsSender } from '../adapters/NativeCommandsSender.mock';
 import { NotificationResponse } from '../interfaces/NotificationEvents';
 import { Platform, AppState } from 'react-native';
-import { NotificationCompletion } from '../interfaces/NotificationCompletion';
+import { NotificationCompletion, NotificationBackgroundFetchResult } from '../interfaces/NotificationCompletion';
 
 describe('EventsRegistry', () => {
   let uut: EventsRegistry;
@@ -119,7 +119,7 @@ describe('EventsRegistry', () => {
 
     it('should invoke finishPresentingNotification', () => {
       const notification: Notification  = new Notification({identifier: 'notificationId'});
-      const response: NotificationCompletion  = {alert: true}
+      const response = NotificationBackgroundFetchResult.NO_DATA;
       
       uut.registerNotificationReceivedBackground((notification, completion) => {
         completion(response);
@@ -133,7 +133,7 @@ describe('EventsRegistry', () => {
     it('should not invoke finishPresentingNotification on Android', () => {
       Platform.OS = 'android';
       const expectedNotification: Notification  = new Notification({identifier: 'notificationId'});
-      const response: NotificationCompletion  = {alert: true}
+      const response = NotificationBackgroundFetchResult.NO_DATA;
       
       uut.registerNotificationReceivedBackground((notification, completion) => {
         completion(response);

--- a/lib/src/events/EventsRegistry.test.ts
+++ b/lib/src/events/EventsRegistry.test.ts
@@ -91,8 +91,8 @@ describe('EventsRegistry', () => {
   
       uut.registerNotificationReceivedBackground(cb);
   
-      expect(mockNativeEventsReceiver.registerNotificationReceived).toHaveBeenCalledTimes(1);
-      expect(mockNativeEventsReceiver.registerNotificationReceived).toHaveBeenCalledWith(expect.any(Function));
+      expect(mockNativeEventsReceiver.registerNotificationReceivedBackground).toHaveBeenCalledTimes(1);
+      expect(mockNativeEventsReceiver.registerNotificationReceivedBackground).toHaveBeenCalledWith(expect.any(Function));
     });
   
     it('should wrap callback with completion block', () => {
@@ -100,7 +100,7 @@ describe('EventsRegistry', () => {
       const notification: Notification  = new Notification({identifier: 'identifier'});
       
       uut.registerNotificationReceivedBackground(wrappedCallback);
-      const call = mockNativeEventsReceiver.registerNotificationReceived.mock.calls[0][0];
+      const call = mockNativeEventsReceiver.registerNotificationReceivedBackground.mock.calls[0][0];
       call(notification);
       
       expect(wrappedCallback).toBeCalledWith(notification, expect.any(Function));
@@ -113,24 +113,24 @@ describe('EventsRegistry', () => {
       uut.registerNotificationReceivedBackground((notification) => {
         expect(notification).toEqual(expectedNotification);
       });
-      const call = mockNativeEventsReceiver.registerNotificationReceived.mock.calls[0][0];
+      const call = mockNativeEventsReceiver.registerNotificationReceivedBackground.mock.calls[0][0];
       call(expectedNotification);
     });
 
-    it('should invoke finishPresentingNotification', () => {
+    it('should invoke finishHandlingBackgroundAction', () => {
       const notification: Notification  = new Notification({identifier: 'notificationId'});
       const response = NotificationBackgroundFetchResult.NO_DATA;
       
       uut.registerNotificationReceivedBackground((notification, completion) => {
         completion(response);
         
-        expect(mockNativeCommandsSender.finishPresentingNotification).toBeCalledWith(notification.identifier, response);
+        expect(mockNativeCommandsSender.finishHandlingBackgroundAction).toBeCalledWith(notification.identifier, response);
       });
-      const call = mockNativeEventsReceiver.registerNotificationReceived.mock.calls[0][0];
+      const call = mockNativeEventsReceiver.registerNotificationReceivedBackground.mock.calls[0][0];
       call(notification);
     });
 
-    it('should not invoke finishPresentingNotification on Android', () => {
+    it('should not invoke finishHandlingBackgroundAction on Android', () => {
       Platform.OS = 'android';
       const expectedNotification: Notification  = new Notification({identifier: 'notificationId'});
       const response = NotificationBackgroundFetchResult.NO_DATA;
@@ -138,9 +138,9 @@ describe('EventsRegistry', () => {
       uut.registerNotificationReceivedBackground((notification, completion) => {
         completion(response);
         expect(expectedNotification).toEqual(notification);
-        expect(mockNativeCommandsSender.finishPresentingNotification).toBeCalledTimes(0);
+        expect(mockNativeCommandsSender.finishHandlingBackgroundAction).toBeCalledTimes(0);
       });
-      const call = mockNativeEventsReceiver.registerNotificationReceived.mock.calls[0][0];
+      const call = mockNativeEventsReceiver.registerNotificationReceivedBackground.mock.calls[0][0];
       call(expectedNotification);
     });
   });

--- a/lib/src/events/EventsRegistry.ts
+++ b/lib/src/events/EventsRegistry.ts
@@ -7,7 +7,7 @@ import {
 import { NotificationActionResponse } from '../interfaces/NotificationActionResponse';
 import { CompletionCallbackWrapper } from '../adapters/CompletionCallbackWrapper';
 import { Notification } from '../DTO/Notification';
-import { NotificationCompletion } from '../interfaces/NotificationCompletion';
+import { NotificationCompletion, NotificationBackgroundFetchResult } from '../interfaces/NotificationCompletion';
 
 export class EventsRegistry {
   constructor(
@@ -23,8 +23,8 @@ export class EventsRegistry {
     return this.nativeEventsReceiver.registerNotificationReceived(this.completionCallbackWrapper.wrapReceivedForegroundCallback(callback));
   }
 
-  public registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: NotificationCompletion) => void) => void): EmitterSubscription {
-    return this.nativeEventsReceiver.registerNotificationReceived(this.completionCallbackWrapper.wrapReceivedBackgroundCallback(callback));
+  public registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: NotificationBackgroundFetchResult) => void) => void): EmitterSubscription {
+    return this.nativeEventsReceiver.registerNotificationReceivedBackground(this.completionCallbackWrapper.wrapReceivedBackgroundCallback(callback));
   }
   
   public registerNotificationOpened(callback: (notification: Notification, completion: () => void, actionResponse?: NotificationActionResponse) => void): EmitterSubscription {

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -7,3 +7,4 @@ export * from './interfaces/EventSubscription';
 export * from './DTO/Notification';
 export * from './interfaces/NotificationEvents';
 export * from './interfaces/NotificationCategory';
+export * from './interfaces/NotificationCompletion';

--- a/lib/src/interfaces/NotificationCompletion.ts
+++ b/lib/src/interfaces/NotificationCompletion.ts
@@ -3,3 +3,9 @@ export interface NotificationCompletion {
   alert?: boolean;
   sound?: boolean;
 }
+
+export enum NotificationBackgroundFetchResult {
+  NEW_DATA = "newData",
+  NO_DATA = "noData",
+  FAILED = "failed",
+}


### PR DESCRIPTION
We still need to use `application:didReceiveRemoteNotification:fetchCompletionHandler:` to handle silent notifications / background updates according to [this](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/pushing_background_updates_to_your_app?language=objc).

I am adding this helper so I can simply call `RNNotifications:didReceiveBackgroundNotification:withCompletionHandler` in my `application:didReceiveRemoteNotification:fetchCompletionHandler:`.