### PR TITLE
Fixed shield.io badge to link rn-notifications in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # React Native Notifications
 ![npm](https://img.shields.io/npm/dw/react-native-notifications.svg)
 [![Build Status](https://img.shields.io/jenkins/s/http/jenkins-oss.wixpress.com:8080/job/multi-react-native-notifications-master.svg)](https://jenkins-oss.wixpress.com/job/multi-react-native-notifications-master/)
-[![npm (tag)](https://img.shields.io/npm/v/react-native-notifications/snapshot.svg)](https://github.com/wix/react-native-navigation/tree/master)
+[![npm (tag)](https://img.shields.io/npm/v/react-native-notifications/latest.svg)](https://github.com/wix/react-native-notifications/tree/master)
+[![npm (tag)](https://img.shields.io/npm/v/react-native-notifications/snapshot.svg)](https://github.com/wix/react-native-notifications/tree/master)
 
 Handle all the aspects of push notifications for your app, including remote and local notifications, interactive notifications, silent notifications, and more.
 


### PR DESCRIPTION
### Description

Added latest npm version tag and changed the links to this repo instead of `react-native-navigation`

### Related Issue

closes https://github.com/wix/react-native-notifications/issues/568