### PR TITLE
Remove check for title in background firebase notifications

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -23,7 +23,7 @@ public class PushNotificationProps {
     }
 
     public boolean isFirebaseBackgroundPayload() {
-        return mBundle.containsKey("google.message_id")
+        return mBundle.containsKey("google.message_id");
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -23,7 +23,7 @@ public class PushNotificationProps {
     }
 
     public boolean isFirebaseBackgroundPayload() {
-        return mBundle.containsKey("google.message_id") && !mBundle.containsKey("title");
+        return mBundle.containsKey("google.message_id")
     }
 
     @Override


### PR DESCRIPTION
Background notifications can still contain a title key, and this is erroneously not showing notifications that it should be.
This fixes getInitialNotification() on Android.