### PR TITLE
Fix cancelLocalNotification crash on iOS

### DIFF
--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -72,7 +72,7 @@ RCT_EXPORT_METHOD(postLocalNotification:(NSDictionary *)notification withId:(non
     [_commandsHandler postLocalNotification:notification withId:notificationId];
 }
 
-RCT_EXPORT_METHOD(cancelLocalNotification:(NSString *)notificationId) {
+RCT_EXPORT_METHOD(cancelLocalNotification:(nonnull NSNumber *)notificationId) {
     [_commandsHandler cancelLocalNotification:notificationId];
 }
 

--- a/lib/ios/RNCommandsHandler.h
+++ b/lib/ios/RNCommandsHandler.h
@@ -25,7 +25,7 @@
 
 - (void)postLocalNotification:(NSDictionary *)notification withId:(NSNumber *)notificationId;
 
-- (void)cancelLocalNotification:(NSString *)notificationId;
+- (void)cancelLocalNotification:(NSNumber *)notificationId;
 
 - (void)cancelAllLocalNotifications;
 

--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -54,7 +54,7 @@
     [_notificationCenter postLocalNotification:notification withId:notificationId];
 }
 
-- (void)cancelLocalNotification:(NSString *)notificationId {
+- (void)cancelLocalNotification:(NSNumber *)notificationId {
     [_notificationCenter cancelLocalNotification:notificationId];
 }
 

--- a/lib/ios/RNNotificationCenter.h
+++ b/lib/ios/RNNotificationCenter.h
@@ -18,7 +18,7 @@ typedef void (^RCTPromiseRejectBlock)(NSString *code, NSString *message, NSError
 
 - (void)postLocalNotification:(NSDictionary *)notification withId:(NSNumber *)notificationId;
 
-- (void)cancelLocalNotification:(NSString *)notificationId;
+- (void)cancelLocalNotification:(NSNumber *)notificationId;
 
 - (void)removeAllDeliveredNotifications;
 

--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -35,9 +35,9 @@
     [[UNUserNotificationCenter currentNotificationCenter] addNotificationRequest:localNotification withCompletionHandler:nil];
 }
 
-- (void)cancelLocalNotification:(NSString *)notificationId {
+- (void)cancelLocalNotification:(NSNumber *)notificationId {
     UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-    [center removePendingNotificationRequestsWithIdentifiers:@[notificationId]];
+    [center removePendingNotificationRequestsWithIdentifiers:@[[notificationId stringValue]]];
 }
 
 - (void)removeAllDeliveredNotifications {


### PR DESCRIPTION
This PR fixes crash on iOS when canceling local notifications.
`cancelLocalNotification` on iOS expected notificationId string which was wrong for the reason that it receives number from the JS side.