### PR TITLE
docs: fix link to API docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ _Upcoming: local notifications, background-state Rx queue (iOS equivalent)_
 
 # Quick Links
 - [Getting Started](https://wix.github.io/react-native-notifications/docs/getting-started)
-- [API](https://wix.github.io/react-native-notifications/docs/general-api)
+- [API](https://wix.github.io/react-native-notifications/api/general-api)
 - [Documentation](https://wix.github.io/react-native-notifications/)
 
 # License


### PR DESCRIPTION
fixed link to API docs in README