### PR TITLE
Handle different SDK than FCM

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdListenerService.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdListenerService.java
@@ -9,6 +9,8 @@ import com.wix.reactnativenotifications.BuildConfig;
 import com.wix.reactnativenotifications.core.notification.IPushNotification;
 import com.wix.reactnativenotifications.core.notification.PushNotification;
 
+import org.json.JSONObject;
+
 import static com.wix.reactnativenotifications.Defs.LOGTAG;
 
 /**
@@ -19,16 +21,20 @@ import static com.wix.reactnativenotifications.Defs.LOGTAG;
 public class FcmInstanceIdListenerService extends FirebaseMessagingService {
 
     @Override
-    public void onMessageReceived(RemoteMessage message){
+    public void onMessageReceived(RemoteMessage message) {
         Bundle bundle = message.toIntent().getExtras();
         if(BuildConfig.DEBUG) Log.d(LOGTAG, "New message from FCM: " + bundle);
 
-        try {
-            final IPushNotification notification = PushNotification.get(getApplicationContext(), bundle);
-            notification.onReceived();
-        } catch (IPushNotification.InvalidNotificationException e) {
-            // An FCM message, yes - but not the kind we know how to work with.
-            if(BuildConfig.DEBUG) Log.v(LOGTAG, "FCM message handling aborted", e);
+        JSONObject data = new JSONObject(message.getData());
+        if (data.has("message")) {
+            try {
+                final IPushNotification notification = PushNotification.get(getApplicationContext(), bundle);
+                notification.onReceived();
+            } catch (IPushNotification.InvalidNotificationException e) {
+                if(BuildConfig.DEBUG) Log.v(LOGTAG, "FCM message handling aborted", e);
+            }
+        } else {
+            Log.d("fonMessageReceived", "having custom key"); // it's from other service than FCM
         }
     }
 }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdListenerService.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmInstanceIdListenerService.java
@@ -34,7 +34,7 @@ public class FcmInstanceIdListenerService extends FirebaseMessagingService {
                 if(BuildConfig.DEBUG) Log.v(LOGTAG, "FCM message handling aborted", e);
             }
         } else {
-            Log.d("fonMessageReceived", "having custom key"); // it's from other service than FCM
+            Log.d("fonMessageReceived", "having a different key than FCM one");
         }
     }
 }


### PR DESCRIPTION
As mentioned [here](https://stackoverflow.com/questions/39385133/how-to-handle-firebase-cloud-messaging-sdk-and-onesignal-sdk-in-a-same-project), having multiple Notification SDKs will cause duplicated notifications.

I assume **message** is the main key to differentiate FCM message and the others.

If you have a better proposal, shoot!