### PR TITLE
Added note about scheduled notifications not implemented on android yet

### DIFF
--- a/website/docs/localNotifications.md
+++ b/website/docs/localNotifications.md
@@ -84,4 +84,4 @@ Notifications.postLocalNotification({
 });
 ```
 
-Upon notification opening (tapping by the device user), all data fields will be delivered as-is).
+Upon notification opening (tapping by the device user), all data fields will be delivered as-is). Note that scheduled notifications are not yet implemented on Android. See [Issue 484](https://github.com/wix/react-native-notifications/issues/484).


### PR DESCRIPTION
Added note that scheduled notifications are not implemented on android yet to avoid confusion. As you can see in issue https://github.com/wix/react-native-notifications/issues/484 this is not quite clear from the docs.