### PR TITLE
Ensure react-native-notifications calls go out on main queue.

### DIFF
--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -30,6 +30,10 @@ RCT_EXPORT_MODULE();
     }
 }
 
+- (dispatch_queue_t)methodQueue {
+    return dispatch_get_main_queue();
+}
+
 #pragma mark - JS interface
 
 RCT_EXPORT_METHOD(requestPermissions) {


### PR DESCRIPTION
I was facing the same issue described by https://github.com/wix/react-native-notifications/issues/184 (specifically when calling `ios.setBadgeCount()`). I'm not a native developer so I don't fully understand what this PR is doing but am just resurrecting the fix proposed by @LeoNatan. It fixes the problems for me when built locally!