### PR TITLE
When the app is in background, registerNotificationOpened wasn't trig…

### DIFF
--- a/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
+++ b/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
@@ -23,6 +23,9 @@ public class NotificationIntentAdapter {
         if (intent != null) {
             Bundle notificationData = intent.getExtras();
             if (notificationData != null && intent.hasExtra(PUSH_NOTIFICATION_EXTRA_NAME)) {
+            if (notificationData != null &&
+                    (intent.hasExtra(PUSH_NOTIFICATION_EXTRA_NAME) ||
+                            notificationData.getString("google.message_id", null) != null)) {
                 return true;
             }
         }


### PR DESCRIPTION
…gered when user presses on notification banner.

See https://github.com/wix/react-native-notifications/pull/614/files