### PR TITLE
FEAT: Adding possibility for notification id to be inserted from background notification

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -60,7 +60,7 @@ public class PushNotification implements IPushNotification {
     @Override
     public void onReceived() throws InvalidNotificationException {
         if (!mAppLifecycleFacade.isAppVisible()) {
-            postNotification(null);
+            postNotification(mNotificationProps.getId());
         }
         notifyReceivedToJS();
     }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -18,6 +18,12 @@ public class PushNotificationProps {
         return getBundleStringFirstNotNull("gcm.notification.body", "body");
     }
 
+    public int getId () {
+        String idAsString = mBundle.getString("id");
+        return idAsString == null ? null : Integer.parseInt(idAsString);
+    }
+
+
     public Bundle asBundle() {
         return (Bundle) mBundle.clone();
     }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotificationProps.java
@@ -19,7 +19,7 @@ public class PushNotificationProps {
     }
 
     public int getId () {
-        String idAsString = mBundle.getString("id");
+        String idAsString = mBundle.getString("identifier");
         return idAsString == null ? null : Integer.parseInt(idAsString);
     }
 


### PR DESCRIPTION
Adding support for notification ID on Android background notification.
To use this feature, the user should pass on the id field on the notification data object. Two notifications that should replace each other should have the same "id" field. 
It solves the https://github.com/wix/react-native-notifications/issues/635 issue