### PR TITLE
Foreground notification fix on android

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -59,9 +59,10 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public void onReceived() throws InvalidNotificationException {
-        if (!mAppLifecycleFacade.isAppVisible()) {
-            postNotification(null);
-        }
+//         if (!mAppLifecycleFacade.isAppVisible()) {
+//             postNotification(null);
+//         }
+        postNotification(null);
         notifyReceivedToJS();
     }
 


### PR DESCRIPTION
Blank notification on foreground only, you can receive notification but it is not working in foreground, only on background.

Thanks to this: https://github.com/wix/react-native-notifications/issues/525#issuecomment-656585578