### PR TITLE
Remove adding the package to the list of packages.

### DIFF
--- a/website/docs/installation-android.md
+++ b/website/docs/installation-android.md
@@ -9,17 +9,6 @@ Add the library to your application class (e.g. `MainApplication.java`):
 ```java
 import com.wix.reactnativenotifications.RNNotificationsPackage;
 
-...
-
-    @Override
-    protected List<ReactPackage> getPackages() {
-       @SuppressWarnings("UnnecessaryLocalVariable")
-       List<ReactPackage> packages = new PackageList(this).getPackages();
-       // ... 
-       // Add the following line: 
-       packages.add(new RNNotificationsPackage(MainApplication.this)); 
-       return packages;
-    }
 ```
 
 ### Receiving push notifications


### PR DESCRIPTION
Remove adding the package to the list of packages. This is done automatically because of auto-linking. The following section is not required anymore. 

    @Override
    protected List<ReactPackage> getPackages() {
       @SuppressWarnings("UnnecessaryLocalVariable")
       List<ReactPackage> packages = new PackageList(this).getPackages();
       // ... 
       // Add the following line: 
       packages.add(new RNNotificationsPackage(MainApplication.this)); 
       return packages;
    }