### PR TITLE
FCM Token Listener application

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmToken.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmToken.java
@@ -75,11 +75,14 @@ public class FcmToken implements IFcmToken {
     }
 
     protected void refreshToken() {
-        FirebaseInstanceId.getInstance().getInstanceId().addOnSuccessListener( new OnSuccessListener<InstanceIdResult>() {
+        FirebaseInstanceId.getInstance().getInstanceId().addOnSuccessListener(new OnSuccessListener<InstanceIdResult>() {
             @Override
             public void onSuccess(InstanceIdResult instanceIdResult) {
                 sToken = instanceIdResult.getToken();
-                if(BuildConfig.DEBUG) Log.i(LOGTAG, "FCM has a new token" + "=" + sToken);
+                if (mAppContext instanceof IFcmTokenListenerApplication) {
+                    ((IFcmTokenListenerApplication) mAppContext).onNewFCMToken(sToken);
+                }
+                if (BuildConfig.DEBUG) Log.i(LOGTAG, "FCM has a new token" + "=" + sToken);
                 sendTokenToJS();
             }
         });

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/IFcmTokenListenerApplication.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/IFcmTokenListenerApplication.java
@@ -1,0 +1,9 @@
+package com.wix.reactnativenotifications.fcm;
+
+/**
+ * API for Applications that want to listen new FCM tokens
+ * whenever its ready.
+ */
+public interface IFcmTokenListenerApplication {
+    void onNewFCMToken(String token);
+}


### PR DESCRIPTION
Sometimes we need to use the FCM token, sync with server and more.
Today the token is sent to the JS, that prevents us from making custom native logic that deals with FCM token.

Changes done as small as possible, it is optional, Instance of Application class can implement the interface in order to receive the token itself to the native side.