### PR TITLE
[Bugfix][Android] Prevent empty notifications when receiving Firebase data messages

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -59,7 +59,7 @@ public class PushNotification implements IPushNotification {
 
     @Override
     public void onReceived() throws InvalidNotificationException {
-        if (!mAppLifecycleFacade.isAppVisible()) {
+        if (!mAppLifecycleFacade.isAppVisible() && !mNotificationProps.isFirebaseBackgroundPayload()) {
             postNotification(null);
         }
         notifyReceivedToJS();

--- a/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notification/PushNotificationTest.java
+++ b/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notification/PushNotificationTest.java
@@ -237,7 +237,7 @@ public class PushNotificationTest {
     public void onReceived_validDataForBackgroundApp_postNotificationAndNotifyJs() throws Exception {
         // Arrange
 
-        setUpForegroundApp();
+        setUpBackgroundApp();
 
         // Act
 
@@ -249,7 +249,7 @@ public class PushNotificationTest {
         ArgumentCaptor<Notification> notificationCaptor = ArgumentCaptor.forClass(Notification.class);
 
         // Notifications should not be visible while app is in foreground
-        verify(mNotificationManager, never()).notify(anyInt(), notificationCaptor.capture());
+        verify(mNotificationManager).notify(anyInt(), notificationCaptor.capture());
 
         // Notifications should be reported to javascript while app is in background
         verify(mJsIOHelper).sendEventToJS(eq(NOTIFICATION_RECEIVED_EVENT_NAME), argThat(new isValidNotification(mNotificationBundle)), eq(mReactContext));


### PR DESCRIPTION
## Current behavior
When receiving Firebase data messages (messages without `title` or `body`), an empty notification is shown.

## New behavior
When receiving  Firebase data messages, the notification is only handled by JS and no notification is shown.

### Other changes
- Tests for the changes above.
- Fixed a duplicated test that wasn't testing what it should (`onReceived_validDataForBackgroundApp_postNotificationAndNotifyJs`)