### PR TITLE
Fixes #627 - First foreground notification is not visible

### DIFF
--- a/lib/ios/RNNotifications.m
+++ b/lib/ios/RNNotifications.m
@@ -18,7 +18,7 @@
 
 - (instancetype)init {
     self = [super init];
-    _store = [RNNotificationsStore new];
+    _store = [RNNotificationsStore sharedInstance];
     _notificationEventHandler = [[RNNotificationEventHandler alloc] initWithStore:_store];
     return self;
 }


### PR DESCRIPTION
I can't see a reason why `RNNotifications.m` should have its own instance of `RNNotificationsStore` so I'm certain it's a bug. That  was what caused the notifications to not be shown the first time