### PR TITLE
action completeHandler must run on main thread

### DIFF
--- a/example/ios/NotificationsExampleAppTests/RNNotificationsStoreTests.m
+++ b/example/ios/NotificationsExampleAppTests/RNNotificationsStoreTests.m
@@ -19,13 +19,13 @@
 }
 
 - (void)testCompleteAction_ShouldInvokeBlock {
-    __block BOOL blockInvoked = NO;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Testing Async Method"];
     void (^testBlock)(void) = ^void() {
-        blockInvoked = YES;
+      [expectation fulfill];
     };
     [_store setActionCompletionHandler:testBlock withCompletionKey:@"actionTestBlock"];
     [_store completeAction:@"actionTestBlock"];
-    XCTAssertTrue(blockInvoked);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 - (void)testCompleteAction_ShouldRemoveBlock {

--- a/example/ios/NotificationsExampleAppTests/RNNotificationsStoreTests.m
+++ b/example/ios/NotificationsExampleAppTests/RNNotificationsStoreTests.m
@@ -29,13 +29,13 @@
 }
 
 - (void)testCompleteAction_ShouldRemoveBlock {
-    __block BOOL blockInvoked = NO;
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Testing Async Method"];
     void (^testBlock)(void) = ^void() {
-        blockInvoked = YES;
+        [expectation fulfill];
     };
     [_store setActionCompletionHandler:testBlock withCompletionKey:@"actionTestBlock"];
     [_store completeAction:@"actionTestBlock"];
-    XCTAssertNil([_store getActionCompletionHandler:@"actionTestBlock"]);
+    [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
 

--- a/lib/ios/RNNotificationsStore.m
+++ b/lib/ios/RNNotificationsStore.m
@@ -48,8 +48,8 @@ NSMutableDictionary* _backgroundActionCompletionHandlers;
     if (completionHandler) {
         dispatch_async(dispatch_get_main_queue(), ^{
             completionHandler();
+            [_actionCompletionHandlers removeObjectForKey:completionKey];
         });
-        [_actionCompletionHandlers removeObjectForKey:completionKey];
     }
 }
 

--- a/lib/ios/RNNotificationsStore.m
+++ b/lib/ios/RNNotificationsStore.m
@@ -46,7 +46,9 @@ NSMutableDictionary* _backgroundActionCompletionHandlers;
 - (void)completeAction:(NSString *)completionKey {
     void (^completionHandler)() = (void (^)())[_actionCompletionHandlers valueForKey:completionKey];
     if (completionHandler) {
-        completionHandler();
+        dispatch_async(dispatch_get_main_queue(), ^{
+            completionHandler();
+        });
         [_actionCompletionHandlers removeObjectForKey:completionKey];
     }
 }


### PR DESCRIPTION
On iOS 14 built with Xcode 12 fixes a crash mentioning that completionHandler should run on the main thread