### PR TITLE
notifyReceivedToJS only when app is visible

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/Defs.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/Defs.java
@@ -6,5 +6,6 @@ public interface Defs {
     String TOKEN_RECEIVED_EVENT_NAME = "remoteNotificationsRegistered";
 
     String NOTIFICATION_RECEIVED_EVENT_NAME = "notificationReceived";
+    String NOTIFICATION_RECEIVED_BACKGROUND_EVENT_NAME = "notificationReceivedBackground";
     String NOTIFICATION_OPENED_EVENT_NAME = "notificationOpened";
 }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -61,7 +61,8 @@ public class PushNotification implements IPushNotification {
     public void onReceived() throws InvalidNotificationException {
         if (!mAppLifecycleFacade.isAppVisible()) {
             postNotification(null);
-        }else{   
+            notifyReceivedBackgroundToJS();
+        } else {
             notifyReceivedToJS();
         }
     }
@@ -203,6 +204,10 @@ public class PushNotification implements IPushNotification {
 
     private void notifyReceivedToJS() {
         mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
+    }
+
+    private void notifyReceivedBackgroundToJS() {
+        mJsIOHelper.sendEventToJS(NOTIFICATION_RECEIVED_BACKGROUND_EVENT_NAME, mNotificationProps.asBundle(), mAppLifecycleFacade.getRunningReactContext());
     }
 
     private void notifyOpenedToJS() {

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -61,8 +61,9 @@ public class PushNotification implements IPushNotification {
     public void onReceived() throws InvalidNotificationException {
         if (!mAppLifecycleFacade.isAppVisible()) {
             postNotification(null);
+        }else{   
+            notifyReceivedToJS();
         }
-        notifyReceivedToJS();
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -21,6 +21,7 @@ import com.wix.reactnativenotifications.core.ProxyService;
 
 import static com.wix.reactnativenotifications.Defs.NOTIFICATION_OPENED_EVENT_NAME;
 import static com.wix.reactnativenotifications.Defs.NOTIFICATION_RECEIVED_EVENT_NAME;
+import static com.wix.reactnativenotifications.Defs.NOTIFICATION_RECEIVED_BACKGROUND_EVENT_NAME;
 
 public class PushNotification implements IPushNotification {
 


### PR DESCRIPTION
When app in the background the js thread is not granted to be running to making sure it is only sent when the app is in FG.