### PR TITLE
[BugFix][iOS] Cleaning up initial notification after resolve

### DIFF
--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -22,7 +22,9 @@
 }
 
 - (void)getInitialNotification:(RCTPromiseResolveBlock)resolve reject:(RCTPromiseRejectBlock)reject {
-    resolve([[RNNotificationsStore sharedInstance] initialNotification]);
+  NSDictionary* initialNotification = [[RNNotificationsStore sharedInstance] initialNotification];
+  [[RNNotificationsStore sharedInstance] setInitialNotification:nil];
+  resolve(initialNotification);
 }
 
 - (void)finishHandlingAction:(NSString *)completionKey {


### PR DESCRIPTION
There is a problem on iOS we encountered in RN application. 
Steps to reproduce: 
- App is dead
- Notification received (with deep link to some screen in app) 
- User opened the notification and navigated to some place in app 
- User performed some actions, which cause app to reload from scratch 
- App is loading from scratch ( initial notification is still there )
- Notification handler takes the initial notification again 
- User navigated to some place in app again

Expected behaviour: 
Initial notification should be cleared. 