### PR TITLE
Fix boolean type when converting to js

### DIFF
--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -79,9 +79,9 @@
 - (void)checkPermissions:(RCTPromiseResolveBlock)resolve {
     [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
         resolve(@{
-                  @"badge": @(settings.badgeSetting == UNNotificationSettingEnabled),
-                  @"sound": @(settings.soundSetting == UNNotificationSettingEnabled),
-                  @"alert": @(settings.alertSetting == UNNotificationSettingEnabled),
+                  @"badge": [NSNumber numberWithBool:settings.badgeSetting == UNNotificationSettingEnabled],
+                  @"sound": [NSNumber numberWithBool:settings.soundSetting == UNNotificationSettingEnabled],
+                  @"alert": [NSNumber numberWithBool:settings.alertSetting == UNNotificationSettingEnabled],
                   });
     }];
 }


### PR DESCRIPTION
In iOS, `@(YES)` is converted as `[NSNumber numberWithBool:]`, generating a `__NSCFBoolean` instance.
While `@(1 == 1)` is converted as `[NSNumber numberWithInt:]`, generating a `__NSCFNumber` instance.
And RN converter treat this differently. The first one becomes bool value, and the second one becomes numberic value.

This PR makes sure the return value from native side will match type declaration in ts file `lib/src/interfaces/NotificationPermissions.ts`:
```
export interface NotificationPermissions {
  badge: boolean;
  alert: boolean;
  sound: boolean;
}
```