### PR TITLE
Make notification id optional fixes #703

### DIFF
--- a/lib/src/Notifications.ts
+++ b/lib/src/Notifications.ts
@@ -54,7 +54,7 @@ export class NotificationsRoot {
   /**
    * postLocalNotification
    */
-  public postLocalNotification(notification: Notification, id: number) {
+  public postLocalNotification(notification: Notification, id?: number) {
     return this.commands.postLocalNotification(notification, id);
   }
 


### PR DESCRIPTION
Makes the id optional when posting a local notification.