### PR TITLE
Expose the multicast property of RNNotifications so it can be used for tweaks

### DIFF
--- a/lib/ios/RNNotifications.h
+++ b/lib/ios/RNNotifications.h
@@ -17,4 +17,6 @@
 + (void)addNativeDelegate:(id<UNUserNotificationCenterDelegate>)delegate;
 + (void)removeNativeDelegate:(id<UNUserNotificationCenterDelegate>)delegate;
 
+- (RNNotificationCenterMulticast*)multicast;
+
 @end

--- a/lib/ios/RNNotifications.m
+++ b/lib/ios/RNNotifications.m
@@ -61,6 +61,10 @@
     [[self sharedInstance] removeNativeDelegate:delegate];
 }
 
+- (RNNotificationCenterMulticast*)multicast {
+    return _notificationCenterMulticast;
+}
+
 - (void)startMonitorNotifications {
     _notificationCenterListener = [[RNNotificationCenterListener alloc] initWithNotificationEventHandler:_notificationEventHandler];
     


### PR DESCRIPTION
We wanted to customize the handling of the notifications for iOS. The only way to do this was to implement a wrapper around the `RNNotificationCenterMulticast` instance. This PR exposes that as an interface method on the `RNNotifications` object.