### PR TITLE
Update getting-started.md AppDelegate section

### DIFF
--- a/website/docs/docs/getting-started.md
+++ b/website/docs/docs/getting-started.md
@@ -43,9 +43,13 @@ $ yarn add react-native-notifications
 $ pod install --project-directory=ios/
 ```
 
-Add the following line at the top of your `AppDelegate.m`
+Add the following line to your `AppDelegate.m`, below the `FB_SONARKIT_ENABLED` definition:
 
 ```objectivec
+#ifdef FB_SONARKIT_ENABLED
+...
+#endif
+
 #import "RNNotifications.h"
 ```
 


### PR DESCRIPTION
This change comes about as a result of this issue: https://github.com/wix/react-native-notifications/issues/662

The docs state to add `#import "RNNotifications.h"` to the top of `AppDelegate.m`, but this cause an error when building the App. 

The import should instead be added below the `#ifdef FB_SONARKIT_ENABLED` definition block.