### PR TITLE
Add ability to request/check more iOS permissions such as critical alerts

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -46,8 +46,8 @@ class NotificationsExampleApp extends Component {
     });
   }
 
-  requestPermissions() {
-    Notifications.registerRemoteNotifications();
+  requestPermissions(options) {
+    Notifications.registerRemoteNotifications(options);
   }
 
   setCategories() {

--- a/lib/ios/RNBridgeModule.m
+++ b/lib/ios/RNBridgeModule.m
@@ -36,8 +36,8 @@ RCT_EXPORT_MODULE();
 
 #pragma mark - JS interface
 
-RCT_EXPORT_METHOD(requestPermissions) {
-    [_commandsHandler requestPermissions];
+RCT_EXPORT_METHOD(requestPermissions:(NSDictionary *)options) {
+    [_commandsHandler requestPermissions:options];
 }
 
 RCT_EXPORT_METHOD(setCategories:(NSArray *)categories) {

--- a/lib/ios/RNCommandsHandler.h
+++ b/lib/ios/RNCommandsHandler.h
@@ -5,7 +5,7 @@
 
 - (instancetype)init;
 
-- (void)requestPermissions;
+- (void)requestPermissions:(NSDictionary *)options;
 
 - (void)setCategories:(NSArray *)categories;
 

--- a/lib/ios/RNCommandsHandler.m
+++ b/lib/ios/RNCommandsHandler.m
@@ -13,8 +13,8 @@
     return self;
 }
 
-- (void)requestPermissions {
-    [_notificationCenter requestPermissions];
+- (void)requestPermissions:(NSDictionary *)options {
+    [_notificationCenter requestPermissions:options];
 }
 
 - (void)setCategories:(NSArray *)categories {

--- a/lib/ios/RNNotificationCenter.h
+++ b/lib/ios/RNNotificationCenter.h
@@ -10,7 +10,7 @@ typedef void (^RCTPromiseRejectBlock)(NSString *code, NSString *message, NSError
 
 - (void)isRegisteredForRemoteNotifications:(RCTPromiseResolveBlock)resolve;
 
-- (void)requestPermissions;
+- (void)requestPermissions:(NSDictionary *)options;
 
 - (void)setCategories:(NSArray *)json;
 

--- a/lib/ios/RNNotificationsTests/Integration/RNCommandsHandlerIntegrationTest.m
+++ b/lib/ios/RNNotificationsTests/Integration/RNCommandsHandlerIntegrationTest.m
@@ -34,7 +34,32 @@
     [[_notificationCenter expect] getNotificationSettingsWithCompletionHandler:[OCMArg invokeBlockWithArgs:settings, nil]];
     [[(id)[UIApplication sharedApplication] expect] registerForRemoteNotifications];
     
-    [_uut requestPermissions];
+    [_uut requestPermissions:@{}];
+    [_notificationCenter verify];
+}
+
+- (void)testRequestPermissions_userAuthorizedPermissionsExtraOptions {
+    UNAuthorizationOptions authOptions = (UNAuthorizationOptionBadge |
+                                          UNAuthorizationOptionSound |
+                                          UNAuthorizationOptionAlert |
+                                          UNAuthorizationOptionAnnouncement |
+                                          UNAuthorizationOptionProvidesAppNotificationSettings |
+                                          UNAuthorizationOptionCriticalAlert |
+                                          UNAuthorizationOptionCarPlay);
+    
+    
+    UNNotificationSettings* settings = [UNNotificationSettings new];
+    [settings setValue:@(UNAuthorizationStatusAuthorized) forKey:@"authorizationStatus"];
+
+    [[_notificationCenter expect] requestAuthorizationWithOptions:authOptions completionHandler:[OCMArg invokeBlockWithArgs:@(YES), [NSNull null], nil]];
+    [[_notificationCenter expect] getNotificationSettingsWithCompletionHandler:[OCMArg invokeBlockWithArgs:settings, nil]];
+    [[(id)[UIApplication sharedApplication] expect] registerForRemoteNotifications];
+    
+    [_uut requestPermissions:@{@"carPlay": @YES,
+                               @"criticalAlert": @YES,
+                               @"providesAppNotificationSettings": @YES,
+                               @"provisional": @YES,
+                               @"announcement": @YES}];
     [_notificationCenter verify];
 }
 
@@ -47,7 +72,7 @@
     [[_notificationCenter expect] getNotificationSettingsWithCompletionHandler:[OCMArg invokeBlockWithArgs:settings, nil]];
     [[(id)[UIApplication sharedApplication] reject] registerForRemoteNotifications];
     
-    [_uut requestPermissions];
+    [_uut requestPermissions:@{}];
     [_notificationCenter verify];
 }
 

--- a/lib/src/Notifications.ts
+++ b/lib/src/Notifications.ts
@@ -11,6 +11,7 @@ import { NotificationChannel } from './interfaces/NotificationChannel';
 import { NotificationsIOS } from './NotificationsIOS';
 import { NotificationsAndroid } from './NotificationsAndroid';
 import { NotificationFactory } from './DTO/NotificationFactory';
+import { NotificationPermissionOptions } from './interfaces/NotificationPermissionOptions';
 
 export class NotificationsRoot {
   public readonly _ios: NotificationsIOS;
@@ -46,8 +47,8 @@ export class NotificationsRoot {
   /**
    * registerRemoteNotifications
    */
-  public registerRemoteNotifications() {
-    this.ios.registerRemoteNotifications();
+  public registerRemoteNotifications(options?: NotificationPermissionOptions) {
+    this.ios.registerRemoteNotifications(options);
     this.android.registerRemoteNotifications();
   }
 

--- a/lib/src/NotificationsIOS.ts
+++ b/lib/src/NotificationsIOS.ts
@@ -2,6 +2,7 @@ import { Notification } from './DTO/Notification';
 import { Commands } from './commands/Commands';
 import { Platform } from 'react-native';
 import { EventsRegistryIOS } from './events/EventsRegistryIOS';
+import { NotificationPermissionOptions } from './interfaces/NotificationPermissionOptions';
 
 export class NotificationsIOS {
   constructor(private readonly commands: Commands, private readonly eventsRegistry: EventsRegistryIOS) {
@@ -19,8 +20,8 @@ export class NotificationsIOS {
   /**
   * Request permissions to send remote notifications
   */
-  public registerRemoteNotifications() {
-    return this.commands.requestPermissions();
+  public registerRemoteNotifications(options?: NotificationPermissionOptions) {
+    return this.commands.requestPermissions(options);
   }
 
   /**

--- a/lib/src/adapters/NativeCommandsSender.ts
+++ b/lib/src/adapters/NativeCommandsSender.ts
@@ -4,11 +4,12 @@ import { NotificationCompletion } from '../interfaces/NotificationCompletion';
 import { NotificationPermissions } from '../interfaces/NotificationPermissions';
 import { NotificationCategory } from '../interfaces/NotificationCategory';
 import { NotificationChannel } from '../interfaces/NotificationChannel';
+import { NotificationPermissionOptions } from '../interfaces/NotificationPermissionOptions';
 
 interface NativeCommandsModule {
   getInitialNotification(): Promise<Object>;
   postLocalNotification(notification: Notification, id: number): void;
-  requestPermissions(): void;
+  requestPermissions(options: NotificationPermissionOptions): void;
   abandonPermissions(): void;
   refreshToken(): void;
   registerPushKit(): void;
@@ -42,8 +43,8 @@ export class NativeCommandsSender {
     return this.nativeCommandsModule.getInitialNotification();
   }
   
-  requestPermissions() {
-    return this.nativeCommandsModule.requestPermissions();
+  requestPermissions(options?: NotificationPermissionOptions) {
+    return this.nativeCommandsModule.requestPermissions(options || {});
   }
 
   abandonPermissions() {

--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -66,8 +66,15 @@ describe('Commands', () => {
 
   describe('requestPermissions', () => {
     it('sends to native', () => {
-      uut.requestPermissions();
-      verify(mockedNativeCommandsSender.requestPermissions()).called();
+      const opts = {};
+      uut.requestPermissions(opts);
+      verify(mockedNativeCommandsSender.requestPermissions(opts)).called();
+    });
+
+    it('sends to native with options', () => {
+      const opts = { criticalAlert: true };
+      uut.requestPermissions(opts);
+      verify(mockedNativeCommandsSender.requestPermissions(opts)).called();
     });
   });
 
@@ -187,7 +194,15 @@ describe('Commands', () => {
     });
 
     it('return negative response from native', async () => {
-      const expectedPermissions: NotificationPermissions = {badge: false, alert: true, sound: false};
+      const expectedPermissions: NotificationPermissions = {
+        badge: false,
+        alert: true,
+        sound: false,
+        announcement: false,
+        carPlay: false,
+        criticalAlert: false,
+        providesAppNotificationSettings: false,
+      };
       when(mockedNativeCommandsSender.checkPermissions()).thenResolve(
         expectedPermissions
       );

--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -6,6 +6,7 @@ import { NotificationChannel } from '../interfaces/NotificationChannel';
 import { NotificationPermissions } from '../interfaces/NotificationPermissions';
 import { UniqueIdProvider } from '../adapters/UniqueIdProvider';
 import { NotificationFactory } from '../DTO/NotificationFactory';
+import { NotificationPermissionOptions } from '../interfaces/NotificationPermissionOptions';
 
 export class Commands {
   constructor(
@@ -30,8 +31,8 @@ export class Commands {
     });
   }
 
-  public requestPermissions() {
-    const result = this.nativeCommandsSender.requestPermissions();
+  public requestPermissions(options?: NotificationPermissionOptions) {
+    const result = this.nativeCommandsSender.requestPermissions(options);
     return result;
   }
 

--- a/lib/src/interfaces/NotificationPermissionOptions.ts
+++ b/lib/src/interfaces/NotificationPermissionOptions.ts
@@ -1,0 +1,6 @@
+export interface NotificationPermissionOptions {
+    carPlay?: boolean;
+    criticalAlert?: boolean;
+    providesAppNotificationSettings?: boolean;
+    announcement?: boolean;
+}

--- a/lib/src/interfaces/NotificationPermissions.ts
+++ b/lib/src/interfaces/NotificationPermissions.ts
@@ -2,4 +2,8 @@ export interface NotificationPermissions {
   badge: boolean;
   alert: boolean;
   sound: boolean;
+  carPlay: boolean;
+  criticalAlert: boolean;
+  providesAppNotificationSettings: boolean;
+  announcement: boolean;
 }

--- a/website/docs/api/general-api.md
+++ b/website/docs/api/general-api.md
@@ -4,8 +4,8 @@ title: General Commands
 sidebar_label: General
 ---
 
-## registerRemoteNotifications()
-Requests remote notification permissions, prompting the user's dialog box on iOS and request a token on Android.
+## registerRemoteNotifications(options?: NotificationPermissionOptions)
+Requests remote notification permissions, prompting the user's dialog box on iOS and request a token on Android. See iOS specific `requestPermissions` for definition of `options`.
 If the user accept the remote notifications permissions, `registerRemoteNotificationsRegistered` event will get called with the device token.
 
 ```js

--- a/website/docs/api/ios-api.md
+++ b/website/docs/api/ios-api.md
@@ -4,8 +4,9 @@ title: iOS Specific Commands
 sidebar_label: iOS specific
 ---
 
-## requestPermissions()
-Requests notification permissions from iOS, prompting the user's dialog box.
+## requestPermissions(options?: NotificationPermissionOptions)
+Requests notification permissions from iOS, prompting the user's dialog box. Options may request
+`criticalAlert` but you must first [Request a Critical Alert Notifications Entitlement](https://developer.apple.com/contact/request/notifications-critical-alerts-entitlement/).
 
 ```js
 Notifications.ios.requestPermissions();

--- a/website/docs/docs/subscription.md
+++ b/website/docs/docs/subscription.md
@@ -42,5 +42,9 @@ Notifications.ios.checkPermissions().then((currentPermissions) => {
     console.log('Badges enabled: ' + !!currentPermissions.badge);
     console.log('Sounds enabled: ' + !!currentPermissions.sound);
     console.log('Alerts enabled: ' + !!currentPermissions.alert);
+    console.log('Car Play enabled: ' + !!currentPermissions.carPlay);
+    console.log('Critical Alerts enabled: ' + !!currentPermissions.criticalAlert);
+    console.log('Provides App Notification Settings enabled: ' + !!currentPermissions.providesAppNotificationSettings);
+    console.log('Announcement enabled: ' + !!currentPermissions.announcement);
 });
 ```


### PR DESCRIPTION
Our application wants to add support for `criticalAlert` notification types. This makes it so you can request nearly all alert types on iOS and check their permissions.