### PR TITLE
foreground notification fix on android

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -64,6 +64,7 @@ public class PushNotification implements IPushNotification {
             postNotification(null);
             notifyReceivedBackgroundToJS();
         } else {
+            postNotification(null);
             notifyReceivedToJS();
         }
     }


### PR DESCRIPTION
not receiving push notification in foreground, solved just adding this postNotification method else condition.
![image](https://user-images.githubusercontent.com/47229808/115418937-4c482c80-a1d0-11eb-99ab-62efe1683342.png)
