### PR TITLE
Changed cancelLocalNotification id type fixing #729

### DIFF
--- a/lib/src/Notifications.ts
+++ b/lib/src/Notifications.ts
@@ -75,7 +75,7 @@ export class NotificationsRoot {
   /**
    * cancelLocalNotification
   */
-  public cancelLocalNotification(notificationId: string) {
+  public cancelLocalNotification(notificationId: number) {
     return this.commands.cancelLocalNotification(notificationId);
   }
 


### PR DESCRIPTION
The local notification id property is a number, thus trying to cancel the notification using a string as the previous param type suggested would raise the following native error:
`java.lang String cannot be cast to java.lang.Double`

while passing a number would work but now typescript would raise an error:

`Argument of type 'number' is not assignable to parameter of type 'string'.ts(2345)`

simply changing the inferred type of the notificationId parameter solves this problem.