### PR TITLE
return to ios.registerRemoteNotifications name

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -52,7 +52,7 @@ class NotificationsExampleApp extends Component {
   }
 
   requestPermissionsIos(options) {
-    Notifications.ios.requestPermissions(options);
+    Notifications.ios.registerRemoteNotifications(options);
   }
 
   requestPermissions() {

--- a/lib/src/Notifications.ts
+++ b/lib/src/Notifications.ts
@@ -47,7 +47,7 @@ export class NotificationsRoot {
    * registerRemoteNotifications
    */
   public registerRemoteNotifications(options?: RequestPermissionsOptions[]) {
-    this.ios.requestPermissions(options);
+    this.ios.registerRemoteNotifications(options);
     this.android.registerRemoteNotifications();
   }
 

--- a/lib/src/NotificationsIOS.ts
+++ b/lib/src/NotificationsIOS.ts
@@ -20,7 +20,7 @@ export class NotificationsIOS {
   /**
   * Request permissions to send remote notifications
   */
-  public requestPermissions(options?: RequestPermissionsOptions[]) {
+  public registerRemoteNotifications(options?: RequestPermissionsOptions[]) {
     return this.commands.requestPermissions(options);
   }
 

--- a/website/docs/api/ios-api.md
+++ b/website/docs/api/ios-api.md
@@ -4,11 +4,11 @@ title: iOS Specific Commands
 sidebar_label: iOS specific
 ---
 
-## requestPermissions(options?: string[])
+## registerRemoteNotifications(options?: string[])
 Requests notification permissions from iOS, prompting the user's dialog box.
 
 ```js
-Notifications.ios.requestPermissions(['ProvidesAppNotificationSettings']);
+Notifications.ios.registerRemoteNotifications(['ProvidesAppNotificationSettings']);
 ```
 
 ## checkPermissions()


### PR DESCRIPTION
I realized that #740 could break builds that uses `Notifications.ios.registerRemoteNotifications` although in docs it was `Notifications.ios.requestPermissions`. Then I decided to return to the original name and to fix the doc to be coherent to this.
