### PR TITLE
Provisional option in iOS registeration

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -143,7 +143,11 @@ class NotificationsExampleApp extends Component {
     return (
       <View style={styles.container}>
         <Button title={'Request permissions'} onPress={this.requestPermissions} testID={'requestPermissions'} />
-        {Platform.OS === 'ios' && <Button title={'Request permissions with app notification settings'} onPress={() => this.requestPermissionsIos(['ProvidesAppNotificationSettings'])} testID={'requestPermissionsWithAppSettings'} />}
+        {Platform.OS === 'ios' && Platform.Version > '12.0' && (<>
+          <Button title={'Request permissions with app notification settings'} onPress={() => this.requestPermissionsIos(['ProvidesAppNotificationSettings'])} testID={'requestPermissionsWithAppSettings'} />
+          <Button title={'Request permissions with provisional'} onPress={() => this.requestPermissionsIos(['Provisional'])} testID={'requestPermissionsWithAppSettings'} />
+          <Button title={'Request permissions with app notification settings and provisional'} onPress={() => this.requestPermissionsIos(['ProvidesAppNotificationSettings', 'Provisional'])} testID={'requestPermissionsWithAppSettings'} />
+        </>)}
         <Button title={'Send local notification'} onPress={this.sendLocalNotification} testID={'sendLocalNotification'} />
         <Button title={'Remove all delivered notifications'} onPress={this.removeAllDeliveredNotifications} />
         {notifications}

--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -8,7 +8,14 @@
     if ([options count] > 0) {
         for (NSString* option in options) {
             if ([option isEqualToString:@"ProvidesAppNotificationSettings"]) {
-                authOptions = (UNAuthorizationOptionBadge | UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionProvidesAppNotificationSettings);
+                if (@available(iOS 12.0, *)) {
+                    authOptions = authOptions | UNAuthorizationOptionProvidesAppNotificationSettings;
+                }
+            }
+            if ([option isEqualToString:@"Provisional"]) {
+                if (@available(iOS 12.0, *)) {
+                    authOptions = authOptions | UNAuthorizationOptionProvisional;
+                }
             }
         }
     }

--- a/lib/ios/RNNotificationsTests/Integration/RNCommandsHandlerIntegrationTest.m
+++ b/lib/ios/RNNotificationsTests/Integration/RNCommandsHandlerIntegrationTest.m
@@ -51,6 +51,19 @@
     [_notificationCenter verify];
 }
 
+- (void)testRequestPermissions_withProvisional {
+    UNAuthorizationOptions authOptions = (UNAuthorizationOptionBadge | UNAuthorizationOptionSound | UNAuthorizationOptionAlert | UNAuthorizationOptionProvisional);
+    UNNotificationSettings* settings = [UNNotificationSettings new];
+    [settings setValue:@(UNAuthorizationStatusAuthorized) forKey:@"authorizationStatus"];
+
+    [[_notificationCenter expect] requestAuthorizationWithOptions:authOptions completionHandler:[OCMArg invokeBlockWithArgs:@(YES), [NSNull null], nil]];
+    [[_notificationCenter expect] getNotificationSettingsWithCompletionHandler:[OCMArg invokeBlockWithArgs:settings, nil]];
+    [[(id)[UIApplication sharedApplication] expect] registerForRemoteNotifications];
+    
+    [_uut requestPermissions:@[@"Provisional"]];
+    [_notificationCenter verify];
+}
+
 - (void)testRequestPermissions_userDeniedPermissions {
     UNAuthorizationOptions authOptions = (UNAuthorizationOptionBadge | UNAuthorizationOptionSound | UNAuthorizationOptionAlert);
     UNNotificationSettings* settings = [UNNotificationSettings new];

--- a/lib/src/adapters/NativeCommandsSender.ts
+++ b/lib/src/adapters/NativeCommandsSender.ts
@@ -28,7 +28,7 @@ interface NativeCommandsModule {
   finishHandlingBackgroundAction(notificationId: string, backgroundFetchResult: string): void;
 }
 
-export type RequestPermissionsOptions = 'ProvidesAppNotificationSettings';
+export type RequestPermissionsOptions = 'ProvidesAppNotificationSettings' | 'Provisional';
 
 export class NativeCommandsSender {
   private readonly nativeCommandsModule: NativeCommandsModule;

--- a/website/docs/api/ios-api.md
+++ b/website/docs/api/ios-api.md
@@ -5,10 +5,18 @@ sidebar_label: iOS specific
 ---
 
 ## registerRemoteNotifications(options?: string[])
-Requests notification permissions from iOS, prompting the user's dialog box.
+Requests notification permissions from iOS, prompting the user's dialog box if needed.
+
+Available options:
+- **`ProvidesAppNotificationSettings`** - An option indicating the iOS notification settings to display a button for in-app notification settings and to be [informed in the app on this event](ios-events.md#appNotificationSettingsLinked).
+- **`Provisional`** - Use provisional authorization to send notifications on a trial basis. Users can then evaluate the notifications and decide whether to authorize them.
+
 
 ```js
-Notifications.ios.registerRemoteNotifications(['ProvidesAppNotificationSettings']);
+Notifications.ios.registerRemoteNotifications([
+  'ProvidesAppNotificationSettings',
+  'Provisional',
+]);
 ```
 
 ## checkPermissions()


### PR DESCRIPTION
Adding `Provisional` option to `ios.registerRemoteNotifications`.
See apple [docs](https://developer.apple.com/documentation/usernotifications/asking_permission_to_use_notifications) for reference.