### PR TITLE
upgrade lodash to 4.17.21

### DIFF
--- a/lib/src/commands/Commands.test.ts
+++ b/lib/src/commands/Commands.test.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { mock, verify, instance, when, anyNumber } from 'ts-mockito';
 
 import { Commands } from './Commands';

--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { NativeCommandsSender, RequestPermissionsOptions } from '../adapters/NativeCommandsSender';
 import { Notification } from '../DTO/Notification';
 import { NotificationCategory } from '../interfaces/NotificationCategory';

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "react-native": ">=0.25.1"
   },
   "devDependencies": {
-    "lodash": "4.17.19",
+    "lodash": "4.17.21",
     "hermes-engine": "0.4.2-rc1",
     "react-autobind": "1.0.6",
     "react": "16.11.0",
@@ -71,7 +71,7 @@
     "@babel/plugin-proposal-export-default-from": "7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "7.2.0",
     "@types/jest": "24.9.0",
-    "@types/lodash": "4.14.153"
+    "@types/lodash": "4.14.170"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"


### PR DESCRIPTION
In order to solve the [security vulnerability](https://github.com/advisories/GHSA-35jh-r3h4-6jhm) lodash should be upgraded
I removed the import of lodash when it's not needed