### PR TITLE
expose provisional state

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -183,7 +183,7 @@ PODS:
     - React-cxxreact (= 0.62.2)
     - React-jsi (= 0.62.2)
   - React-jsinspector (0.62.2)
-  - react-native-notifications (3.4.2):
+  - react-native-notifications (4.0.0):
     - React-Core
   - React-RCTActionSheet (0.62.2):
     - React-Core/RCTActionSheetHeaders (= 0.62.2)
@@ -354,7 +354,7 @@ SPEC CHECKSUMS:
   React-jsi: b6dc94a6a12ff98e8877287a0b7620d365201161
   React-jsiexecutor: 1540d1c01bb493ae3124ed83351b1b6a155db7da
   React-jsinspector: 512e560d0e985d0e8c479a54a4e5c147a9c83493
-  react-native-notifications: 51ed8167f70f01c5000ba81a4465ea98b4612e23
+  react-native-notifications: 18675bc9c976f9f23e722d4b150fcc30d06fc8fc
   React-RCTActionSheet: f41ea8a811aac770e0cc6e0ad6b270c644ea8b7c
   React-RCTAnimation: 49ab98b1c1ff4445148b72a3d61554138565bad0
   React-RCTBlob: a332773f0ebc413a0ce85942a55b064471587a71
@@ -369,4 +369,4 @@ SPEC CHECKSUMS:
 
 PODFILE CHECKSUM: 9915be56de9d009ce5a3ab024f14f80ca53c9b92
 
-COCOAPODS: 1.9.3
+COCOAPODS: 1.10.1

--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -113,6 +113,7 @@
         if (@available(iOS 12.0, *)) {
             allSettings[@"criticalAlert"] = [NSNumber numberWithBool:settings.criticalAlertSetting == UNNotificationSettingEnabled];
             allSettings[@"providesAppNotificationSettings"] = [NSNumber numberWithBool:settings.providesAppNotificationSettings];
+            allSettings[@"provisional"] = [NSNumber numberWithBool:settings.authorizationStatus == UNAuthorizationStatusProvisional];
         }
         if (@available(iOS 13.0, *)) {
             allSettings[@"announcement"] = [NSNumber numberWithBool:settings.announcementSetting == UNNotificationSettingEnabled];

--- a/lib/ios/RNNotifications.h
+++ b/lib/ios/RNNotifications.h
@@ -1,6 +1,7 @@
 #import <UIKit/UIKit.h>
 #import <PushKit/PushKit.h>
 #import <UserNotifications/UserNotifications.h>
+#import "RNNotificationCenterMulticast.h"
 
 @interface RNNotifications : NSObject
 
@@ -16,5 +17,7 @@
 
 + (void)addNativeDelegate:(id<UNUserNotificationCenterDelegate>)delegate;
 + (void)removeNativeDelegate:(id<UNUserNotificationCenterDelegate>)delegate;
+
+- (RNNotificationCenterMulticast*)multicast;
 
 @end

--- a/lib/ios/RNNotifications.m
+++ b/lib/ios/RNNotifications.m
@@ -61,6 +61,10 @@
     [[self sharedInstance] removeNativeDelegate:delegate];
 }
 
+- (RNNotificationCenterMulticast*)multicast {
+    return _notificationCenterMulticast;
+}
+
 - (void)startMonitorNotifications {
     _notificationCenterListener = [[RNNotificationCenterListener alloc] initWithNotificationEventHandler:_notificationEventHandler];
     

--- a/website/docs/docs/subscription.md
+++ b/website/docs/docs/subscription.md
@@ -44,7 +44,8 @@ Notifications.ios.checkPermissions().then((currentPermissions) => {
     console.log('Alerts enabled: ' + !!currentPermissions.alert);
     console.log('Car Play enabled: ' + !!currentPermissions.carPlay);
     console.log('Critical Alerts enabled: ' + !!currentPermissions.criticalAlert);
+    console.log('Provisioanl enabled: ' + !!currentPermissions.provisional);
     console.log('Provides App Notification Settings enabled: ' + !!currentPermissions.providesAppNotificationSettings);
-		console.log('Announcement enabled: ' + !!currentPermissions.announcement);
+	console.log('Announcement enabled: ' + !!currentPermissions.announcement);
 });
 ```


### PR DESCRIPTION
Continuing #752:
returning whether `provisional` is enabled in `Notifications.ios.checkPermissions()`

Added here #731 changes in order to enhance releasing