### PR TITLE
resiter remote on provisional approve

### DIFF
--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -33,7 +33,7 @@
     [UNUserNotificationCenter.currentNotificationCenter requestAuthorizationWithOptions:authOptions completionHandler:^(BOOL granted, NSError * _Nullable error) {
         if (!error && granted) {
             [UNUserNotificationCenter.currentNotificationCenter getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings * _Nonnull settings) {
-                if (settings.authorizationStatus == UNAuthorizationStatusAuthorized) {
+                if (settings.authorizationStatus == UNAuthorizationStatusAuthorized || settings.authorizationStatus == UNAuthorizationStatusProvisional) {
                     dispatch_async(dispatch_get_main_queue(), ^{
                         [[UIApplication sharedApplication] registerForRemoteNotifications];
                     });


### PR DESCRIPTION
continuing #733, we want to register to remote notifications on provisional approve.