### PR TITLE
fixing callback for registerNotificationReceivedBackground

### DIFF
--- a/lib/src/events/EventsRegistry.ts
+++ b/lib/src/events/EventsRegistry.ts
@@ -1,36 +1,36 @@
 import { EmitterSubscription } from 'react-native';
-import { NativeEventsReceiver } from '../adapters/NativeEventsReceiver';
-import {
-  Registered,
-  RegistrationError
-} from '../interfaces/NotificationEvents';
-import { NotificationActionResponse } from '../interfaces/NotificationActionResponse';
 import { CompletionCallbackWrapper } from '../adapters/CompletionCallbackWrapper';
+import { NativeEventsReceiver } from '../adapters/NativeEventsReceiver';
 import { Notification } from '../DTO/Notification';
-import { NotificationCompletion, NotificationBackgroundFetchResult } from '../interfaces/NotificationCompletion';
+import { NotificationActionResponse } from '../interfaces/NotificationActionResponse';
+import { NotificationCompletion } from '../interfaces/NotificationCompletion';
+import {
+    Registered,
+    RegistrationError
+} from '../interfaces/NotificationEvents';
 
 export class EventsRegistry {
   constructor(
     private nativeEventsReceiver: NativeEventsReceiver,
-    private completionCallbackWrapper: CompletionCallbackWrapper) 
+    private completionCallbackWrapper: CompletionCallbackWrapper)
   {}
 
   public registerRemoteNotificationsRegistered(callback: (event: Registered) => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerRemoteNotificationsRegistered(callback);
   }
-  
+
   public registerNotificationReceivedForeground(callback: (notification: Notification, completion: (response: NotificationCompletion) => void) => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerNotificationReceived(this.completionCallbackWrapper.wrapReceivedForegroundCallback(callback));
   }
 
-  public registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: NotificationBackgroundFetchResult) => void) => void): EmitterSubscription {
+  public registerNotificationReceivedBackground(callback: (notification: Notification, completion: (response: NotificationCompletion) => void) => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerNotificationReceivedBackground(this.completionCallbackWrapper.wrapReceivedBackgroundCallback(callback));
   }
-  
+
   public registerNotificationOpened(callback: (notification: Notification, completion: () => void, actionResponse?: NotificationActionResponse) => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerNotificationOpened(this.completionCallbackWrapper.wrapOpenedCallback(callback));
   }
-  
+
   public registerRemoteNotificationsRegistrationFailed(callback: (event: RegistrationError) => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerRemoteNotificationsRegistrationFailed(callback);
   }


### PR DESCRIPTION
Changes the callback argument of `registerNotificationReceivedBackground` from `NotificationBackgroundFetchResult` to `NotificationCompletion` (as mentioned in the documentation https://wix.github.io/react-native-notifications/docs/notifications-events)