### PR TITLE
Data-only notifications should not show empty notifications

### DIFF
--- a/lib/android/app/src/main/AndroidManifest.xml
+++ b/lib/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         <service android:name=".core.ProxyService"/>
 
         <service
-            android:name=".fcm.FcmInstanceIdListenerService">
+            android:name=".fcm.FcmInstanceIdListenerService"
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
                 <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -87,9 +87,14 @@ public class PushNotification implements IPushNotification {
     }
 
     protected int postNotification(Integer notificationId) {
+        if (mNotificationProps.getTitle() == null && mNotificationProps.getBody() == null) {
+            return -1;
+        }
+
         final PendingIntent pendingIntent = getCTAPendingIntent();
         final Notification notification = buildNotification(pendingIntent);
         return postNotification(notification, notificationId);
+
     }
 
     protected void digestNotification() {

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -94,7 +94,6 @@ public class PushNotification implements IPushNotification {
         final PendingIntent pendingIntent = getCTAPendingIntent();
         final Notification notification = buildNotification(pendingIntent);
         return postNotification(notification, notificationId);
-
     }
 
     protected void digestNotification() {

--- a/lib/ios/RNNotificationEventHandler.m
+++ b/lib/ios/RNNotificationEventHandler.m
@@ -38,7 +38,12 @@
         NSString *uuid = [[NSUUID UUID] UUIDString];
         [_store setBackgroundActionCompletionHandler:^(UIBackgroundFetchResult result) {
             dispatch_async(dispatch_get_main_queue(), ^{
-                completionHandler(result);
+                @try {
+                    completionHandler(result);
+                }
+                @catch (NSException *exception) {
+                    NSLog(@"main: Caught %@: %@", [exception name], [exception reason]);
+                }            
             });
         } withCompletionKey:uuid];
         [RNEventEmitter sendEvent:RNNotificationReceivedBackground body:[RNNotificationParser parseNotificationUserInfo:userInfo withIdentifier:uuid]];

--- a/lib/ios/RNNotificationEventHandler.m
+++ b/lib/ios/RNNotificationEventHandler.m
@@ -36,23 +36,12 @@
 - (void)didReceiveBackgroundNotification:(NSDictionary *)userInfo withCompletionHandler:(void (^)(UIBackgroundFetchResult))completionHandler {
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
         NSString *uuid = [[NSUUID UUID] UUIDString];
-        __block BOOL completionHandlerCalled = NO;
-        dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
         [_store setBackgroundActionCompletionHandler:^(UIBackgroundFetchResult result) {
             dispatch_async(dispatch_get_main_queue(), ^{
                 completionHandler(result);
             });
-            completionHandlerCalled = YES;
-            dispatch_semaphore_signal(semaphore);
         } withCompletionKey:uuid];
         [RNEventEmitter sendEvent:RNNotificationReceivedBackground body:[RNNotificationParser parseNotificationUserInfo:userInfo withIdentifier:uuid]];
-        // Allow 25 seconds for this to process. If not finished call the callback with failed.
-        dispatch_semaphore_wait(semaphore, dispatch_time(DISPATCH_TIME_NOW, 25 * NSEC_PER_SEC));
-        if (!completionHandlerCalled) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                completionHandler(UIBackgroundFetchResultFailed);
-            });
-        }
     });
 }
 


### PR DESCRIPTION
As described in this issue https://github.com/wix/react-native-notifications/issues/684 notifications are displayed as empty notifications in Android when no title and body is set. 

This PR mitigates that by not creating a notification if both are not available.

I couldn't find a CONTRIBUTING file so I'm just pushing this as a PR. Let me know if something is off or needs fixing. I've tested this, obviously, and it works as intended.