### PR TITLE
Data-only notifications should not show empty notifications

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -87,9 +87,14 @@ public class PushNotification implements IPushNotification {
     }
 
     protected int postNotification(Integer notificationId) {
+        if (mNotificationProps.getTitle() == null && mNotificationProps.getBody() == null) {
+            return -1;
+        }
+
         final PendingIntent pendingIntent = getCTAPendingIntent();
         final Notification notification = buildNotification(pendingIntent);
         return postNotification(notification, notificationId);
+
     }
 
     protected void digestNotification() {

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -94,7 +94,6 @@ public class PushNotification implements IPushNotification {
         final PendingIntent pendingIntent = getCTAPendingIntent();
         final Notification notification = buildNotification(pendingIntent);
         return postNotification(notification, notificationId);
-
     }
 
     protected void digestNotification() {


### PR DESCRIPTION
As described in this issue #684 notifications are displayed as empty notifications in Android when no title and body is set.

This PR mitigates that by not creating a notification if both are not available.

I couldn't find a CONTRIBUTING file so I'm just pushing this as a PR. Let me know if something is off or needs fixing. I've tested this, obviously, and it works as intended.