### PR TITLE
fix: Add missing `android:exported` to `service`

### DIFF
--- a/lib/android/app/src/main/AndroidManifest.xml
+++ b/lib/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,8 @@
         <service android:name=".core.ProxyService"/>
 
         <service
-            android:name=".fcm.FcmInstanceIdListenerService">
+            android:name=".fcm.FcmInstanceIdListenerService"
+            android:exported="true">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
                 <action android:name="com.google.firebase.INSTANCE_ID_EVENT" />


### PR DESCRIPTION
It's required since Android 12 and makes apps targeting Android 12 or higher fail to build.