### PR TITLE
create default channel only when no existing channel

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/notification/PushNotification.java
@@ -225,11 +225,15 @@ public class PushNotification implements IPushNotification {
 
     private void initDefaultChannel(Context context) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel defaultChannel = new NotificationChannel(DEFAULT_CHANNEL_ID,
-                    DEFAULT_CHANNEL_NAME,
-                    NotificationManager.IMPORTANCE_DEFAULT);
             final NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-            notificationManager.createNotificationChannel(defaultChannel);
+            if (notificationManager.getNotificationChannels().size() == 0) {
+                NotificationChannel defaultChannel = new NotificationChannel(
+                    DEFAULT_CHANNEL_ID,
+                    DEFAULT_CHANNEL_NAME,
+                    NotificationManager.IMPORTANCE_DEFAULT
+                );
+                notificationManager.createNotificationChannel(defaultChannel);
+            }
         }
     }
 }

--- a/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notification/PushNotificationTest.java
+++ b/lib/android/app/src/test/java/com/wix/reactnativenotifications/core/notification/PushNotificationTest.java
@@ -2,6 +2,7 @@ package com.wix.reactnativenotifications.core.notification;
 
 import android.app.Activity;
 import android.app.Notification;
+import android.app.NotificationChannel;
 import android.app.NotificationManager;
 import android.content.Context;
 import android.content.Intent;
@@ -32,7 +33,6 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.Shadows;
 import org.robolectric.shadows.ShadowNotification;
 
-import static com.wix.reactnativenotifications.Defs.NOTIFICATION_RECEIVED_BACKGROUND_EVENT_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,6 +44,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.argThat;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import edu.emory.mathcs.backport.java.util.Arrays;
 
 @RunWith(RobolectricTestRunner.class)
 public class PushNotificationTest {
@@ -302,6 +307,24 @@ public class PushNotificationTest {
         uut.onPostRequest(null);
 
         verify(mNotificationManager, never()).notify(anyInt(), any(Notification.class));
+    }
+
+    @Test
+    public void onCreate_noExistingChannel_createDefaultChannel() throws Exception {
+        createUUT();
+
+        verify(mNotificationManager).createNotificationChannel(any(NotificationChannel.class));
+    }
+
+    @Test
+    public void onCreate_existingChannel_notCreateDefaultChannel() throws Exception {
+        List<NotificationChannel> existingChannel = new ArrayList<>();
+        existingChannel.add(new NotificationChannel("id", "name", 1));
+        when(mNotificationManager.getNotificationChannels()).thenReturn(existingChannel);
+
+        createUUT();
+
+        verify(mNotificationManager, never()).createNotificationChannel(any(NotificationChannel.class));
     }
 
     protected PushNotification createUUT() {


### PR DESCRIPTION
The default channel shouldn't be built if there's already another channel, never mind if the existing one is the default or some other channel. 