### PR TITLE
Exposes new event: remoteNotificationsRegistrationDenied

### DIFF
--- a/lib/ios/RNEventEmitter.h
+++ b/lib/ios/RNEventEmitter.h
@@ -1,6 +1,7 @@
 #import <React/RCTEventEmitter.h>
 
 static NSString* const RNRegistered                  = @"remoteNotificationsRegistered";
+static NSString* const RNRegistrationDenied          = @"remoteNotificationsRegistrationDenied";
 static NSString* const RNRegistrationFailed          = @"remoteNotificationsRegistrationFailed";
 static NSString* const RNPushKitRegistered           = @"pushKitRegistered";
 static NSString* const RNNotificationReceived        = @"notificationReceived";

--- a/lib/ios/RNEventEmitter.m
+++ b/lib/ios/RNEventEmitter.m
@@ -6,6 +6,7 @@ RCT_EXPORT_MODULE();
 
 -(NSArray<NSString *> *)supportedEvents {
     return @[RNRegistered,
+             RNRegistrationDenied,
              RNRegistrationFailed,
              RNPushKitRegistered,
              RNNotificationReceived,

--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -40,6 +40,9 @@
                 }
             }];
         }
+        if (!error && !granted) {
+          [RNEventEmitter sendEvent:RNRegistrationDenied body:nil];
+        }
     }];
 }
 

--- a/lib/src/adapters/NativeEventsReceiver.ts
+++ b/lib/src/adapters/NativeEventsReceiver.ts
@@ -25,13 +25,13 @@ export class NativeEventsReceiver {
   }
 
   public registerNotificationReceived(callback: (notification: Notification) => void): EmitterSubscription {
-    return this.emitter.addListener('notificationReceived', (payload) => {
+    return this.emitter.addListener('notificationReceived', (payload: unknown) => {
       callback(this.notificationFactory.fromPayload(payload));
     });
   }
 
   public registerNotificationReceivedBackground(callback: (notification: Notification) => void): EmitterSubscription {
-    return this.emitter.addListener('notificationReceivedBackground', (payload) => {
+    return this.emitter.addListener('notificationReceivedBackground', (payload: unknown) => {
       callback(this.notificationFactory.fromPayload(payload));
     });
   }

--- a/lib/src/adapters/NativeEventsReceiver.ts
+++ b/lib/src/adapters/NativeEventsReceiver.ts
@@ -50,4 +50,8 @@ export class NativeEventsReceiver {
   public registerRemoteNotificationsRegistrationFailed(callback: (event: RegistrationError) => void): EmitterSubscription {
     return this.emitter.addListener('remoteNotificationsRegistrationFailed', callback);
   }
+
+  public registerRemoteNotificationsRegistrationDenied(callback: () => void): EmitterSubscription {
+    return this.emitter.addListener('remoteNotificationsRegistrationDenied', callback);
+  }
 }

--- a/lib/src/events/EventsRegistry.ts
+++ b/lib/src/events/EventsRegistry.ts
@@ -37,5 +37,5 @@ export class EventsRegistry {
 
   public registerRemoteNotificationsRegistrationDenied(callback: () => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerRemoteNotificationsRegistrationDenied(callback);
-}
+  }
 }

--- a/lib/src/events/EventsRegistry.ts
+++ b/lib/src/events/EventsRegistry.ts
@@ -34,4 +34,8 @@ export class EventsRegistry {
   public registerRemoteNotificationsRegistrationFailed(callback: (event: RegistrationError) => void): EmitterSubscription {
     return this.nativeEventsReceiver.registerRemoteNotificationsRegistrationFailed(callback);
   }
+
+  public registerRemoteNotificationsRegistrationDenied(callback: () => void): EmitterSubscription {
+    return this.nativeEventsReceiver.registerRemoteNotificationsRegistrationDenied(callback);
+}
 }

--- a/website/docs/api/general-events.md
+++ b/website/docs/api/general-events.md
@@ -60,3 +60,12 @@ Notifications.events().registerRemoteNotificationsRegistrationFailed((event: Reg
   console.log(event.code, event.localizedDescription, event.domain);
 });
 ```
+
+## registerRemoteNotificationsDenied()
+Fired when the user does not grant permission to receive push notifications. Typically occurs when pressing the "Don't Allow" button in iOS permissions overlay.
+
+```js
+Notifications.events().registerRemoteNotificationRegistrationDenied(() => {
+  console.log('Notification permissions not granted')
+})
+```


### PR DESCRIPTION
On iOS, calling `requestPermissions` causes a permission dialog to appear.

![image](https://user-images.githubusercontent.com/353729/158819662-eba8bd7d-522c-4c69-8076-38d340b00faa.png)

Pressing OK in this dialog will eventually emit a `registerRemoteNotificationsRegistered` or `registerRemoteNotificationsFailed` event.

However, there's no event emitted if the user chooses "Don't Allow", so if the implementor is attempting to do something in their app depending on which action has been taken, they are unable to do so.

This work exposes a new event called: `remoteNotificationsRegistrationDenied` that is emitted when `requestAuthorizationWithOptions` has been executed without error but with `granted` set to 'NO'.

Related:
- https://github.com/wix/react-native-notifications/issues/669#issuecomment-1069338103
- https://github.com/wix/react-native-notifications/issues/811