### PR TITLE
Fix incorrect method name header in api docs

### DIFF
--- a/website/docs/api/general-events.md
+++ b/website/docs/api/general-events.md
@@ -61,7 +61,7 @@ Notifications.events().registerRemoteNotificationsRegistrationFailed((event: Reg
 });
 ```
 
-## registerRemoteNotificationsDenied()
+## registerRemoteNotificationsRegistrationDenied()
 Fired when the user does not grant permission to receive push notifications. Typically occurs when pressing the "Don't Allow" button in iOS permissions overlay.
 
 ```js


### PR DESCRIPTION
Noticed an incorrect method name in the documentation related to `registerRemoteNotificationsRegistrationDenied`.