### PR TITLE
FIX #835: null mNotification

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -88,8 +88,10 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
                 return;
             }
 
-            InitialNotificationHolder.getInstance().clear();
             result = Arguments.fromBundle(notification.asBundle());
+            InitialNotificationHolder.getInstance().clear();
+        } catch (NullPointerException e) {
+            Log.e(LOGTAG, "getInitialNotification: Null pointer exception");
         } finally {
             promise.resolve(result);
         }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
@@ -47,7 +47,7 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
             return false;
         }
 
-        return mReactContext.hasActiveCatalystInstance();
+        return mReactContext.hasActiveReactInstance();
     }
 
     @Override


### PR DESCRIPTION
In order to fix #835 we changed the clear operation to occur after the arguments' extraction.
also changed deprecated `hasActiveCatalystInstance` to `hasActiveReactInstance`