### PR TITLE
FIX 867: add deprecated hasActiveCatalystInstance for old RN

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
@@ -47,7 +47,11 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
             return false;
         }
 
-        return mReactContext.hasActiveReactInstance();
+        try {
+            return mReactContext.hasActiveCatalystInstance();
+        } catch (Exception e) {
+            return mReactContext.hasActiveReactInstance();
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix #867 
Although hasActiveCatalystInstance is [deprecated](https://github.com/facebook/react-native/blob/09a21f0f3790d42e766d865fd3eb8b1d04a847f7/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L189), devs are still using old versions of RN so we brought it back within a `try` block