### PR TITLE
receive notifiction callback when an app is killed

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/JSNotifyWhenKilledTask.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/JSNotifyWhenKilledTask.java
@@ -1,0 +1,74 @@
+package com.wix.reactnativenotifications;
+
+
+import android.app.ActivityManager;
+import android.app.ActivityManager.RunningAppProcessInfo;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.facebook.react.HeadlessJsTaskService;
+import com.facebook.react.ReactApplication;
+import com.facebook.react.ReactInstanceManager;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.jstasks.HeadlessJsTaskConfig;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+public class JSNotifyWhenKilledTask extends HeadlessJsTaskService {
+    static final String TAG = "[JSNotifyWhenKilledTask]";
+
+    @Override
+    protected @Nullable
+    HeadlessJsTaskConfig getTaskConfig(Intent intent) {
+        Bundle extras = intent.getExtras();
+        
+        if (extras == null) return null;
+
+        for (String key : extras.keySet()) {
+            Object value = extras.get(key);
+            if (value == null) {
+                continue;
+            }
+            Log.d("[JSNotifyWhenKilledTask]", "[bundleItem]:" + String.format("%s %s (%s)", key,
+                    value.toString(), value.getClass().getName()));
+        }
+
+        if (this.isApplicationInForeground()) {
+            // sendToJS(extras);
+            return null;
+        }
+        return new HeadlessJsTaskConfig("JSNotifyWhenKilledTask", Arguments.fromBundle(extras), 0, false);
+    }
+
+    // public void sendToJS(Bundle bundle) {
+    //     ReactInstanceManager mReactInstanceManager = ((ReactApplication) getApplication()).getReactNativeHost().getReactInstanceManager();
+    //     ReactContext context = mReactInstanceManager.getCurrentReactContext();
+    //     RNPushNotificationJsDelivery jsDelivery = new RNPushNotificationJsDelivery((ReactApplicationContext) context);
+    //     jsDelivery.notifyNotificationAction(bundle);
+    // }
+
+    public boolean isApplicationInForeground() {
+        ActivityManager activityManager = (ActivityManager) this.getSystemService(ACTIVITY_SERVICE);
+        List<RunningAppProcessInfo> processInfos = activityManager.getRunningAppProcesses();
+        if (processInfos != null) {
+            for (RunningAppProcessInfo processInfo : processInfos) {
+                if (processInfo.processName.equals(getApplication().getPackageName())) {
+                    if (processInfo.importance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND) {
+                        for (String d : processInfo.pkgList) {
+                            //TelecomManager telM = (TelecomManager) getApplicationContext().getSystemService(Context.TELECOM_SERVICE);
+                            //boolean isInCall = telM.isInCall();
+                            //return !isInCall;
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/AppLifecycleFacade.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/AppLifecycleFacade.java
@@ -13,6 +13,7 @@ public interface AppLifecycleFacade {
     ReactContext getRunningReactContext();
     boolean isAppVisible();
     boolean isAppDestroyed();
+    boolean isAppStarted();
     void addVisibilityListener(AppVisibilityListener listener);
     void removeVisibilityListener(AppVisibilityListener listener);
 }

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
@@ -16,6 +16,7 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
     private ReactContext mReactContext;
     private boolean mIsVisible;
     private boolean mIsDestroyed;
+    private boolean mIsStarted;
     private Set<AppVisibilityListener> mListeners = new CopyOnWriteArraySet<>();
 
     public void init(ReactContext reactContext) {
@@ -68,6 +69,11 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
     @Override
     public boolean isAppDestroyed() {
         return mIsDestroyed;
+    }
+
+    @Override
+    public boolean isAppStarted() {
+        return mIsStarted;
     }
 
     @Override


### PR DESCRIPTION
This is to address https://github.com/wix/react-native-notifications/issues/865

Now an Android  user can receive a push notification callback when an app is in dead/killed state and this is a 'data' notification

The following is required at application side:

1)  to add `<service android:name="com.wix.reactnativenotifications.JSNotifyWhenKilledTask" />` into `AndroidManifest.xml `file

2) and now you can process the notifications in killed/dead state via the following code snippet:

```    
    const { AppRegistry } = require("react-native");

    // https://reactnative.dev/docs/headless-js-android
    //
    AppRegistry.registerHeadlessTask(
      "JSNotifyWhenKilledTask",
      () => {
        return async (notificationBundle) => {
          console.log('[JSNotifyWhenKilledTask] notificationBundle', notificationBundle);

  
        }
      },
    );
```