### PR TITLE
fix: remove deprecated config

### DIFF
--- a/react-native.config.js
+++ b/react-native.config.js
@@ -7,7 +7,6 @@ module.exports = {
         packageInstance: 'new RNNotificationsPackage(reactNativeHost.getApplication())',
       }
     },
-    assets: []
   },
   project: {
     ios: {


### PR DESCRIPTION
Fixes #881 

Removed deprecated parameter from react-native.config.js, causing autolinking to fail from react-native/cli v8

