### PR TITLE
add: pending intent immutable flag to NotificationIntentAdapter

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
@@ -17,7 +17,7 @@ public class NotificationIntentAdapter {
         if (canHandleTrampolineActivity(appContext)) {
             Intent intent = new Intent(appContext, ProxyService.class);
             intent.putExtra(PUSH_NOTIFICATION_EXTRA_NAME, notification.asBundle());
-            return PendingIntent.getService(appContext, (int) System.currentTimeMillis(), intent, PendingIntent.FLAG_ONE_SHOT);
+            return PendingIntent.getService(appContext, (int) System.currentTimeMillis(), intent, PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
         } else {
             Intent mainActivityIntent = appContext.getPackageManager().getLaunchIntentForPackage(appContext.getPackageName());
             mainActivityIntent.putExtra(PUSH_NOTIFICATION_EXTRA_NAME, notification.asBundle());


### PR DESCRIPTION
Google Play's target API level requirement increased to API 31:
https://developer.android.com/google/play/requirements/target-sdk#pre12

One of the requirements is to always specify the mutability of each PendingIntent object:
https://developer.android.com/google/play/requirements/target-sdk#pre12:~:text=Pending%20intent%20mutability%3A%20You%20must%20specify%20the%20mutability%20of%20each%20PendingIntent%20object%20that%20your%20app%20creates.

This PR adds the `PendingIntent.FLAG_IMMUTABLE` to the only place where it was needed.
