### PR TITLE
Fixed Android 31 issues

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsModule.java
@@ -63,7 +63,7 @@ public class RNNotificationsModule extends ReactContextBaseJavaModule implements
     @Override
     public void onNewIntent(Intent intent) {
         if (NotificationIntentAdapter.canHandleIntent(intent)) {
-            Bundle notificationData = intent.getExtras();
+            Bundle notificationData = NotificationIntentAdapter.extractPendingNotificationDataFromIntent(intent);
             final IPushNotification notification = PushNotification.get(getReactApplicationContext().getApplicationContext(), notificationData);
             if (notification != null) {
                 notification.onOpened();

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -61,7 +61,11 @@ public class RNNotificationsPackage implements ReactPackage, AppLifecycleFacade.
         final IPushNotificationsDrawer notificationsDrawer = PushNotificationsDrawer.get(mApplication.getApplicationContext());
         notificationsDrawer.onNewActivity(activity);
 
-        callOnOpenedIfNeed(activity);
+        Intent intent = activity.getIntent();
+        boolean launchedFromHistory = intent != null ? (intent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0 : false;
+        if (!launchedFromHistory) {
+            callOnOpenedIfNeed(activity);
+        }
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/RNNotificationsPackage.java
@@ -66,9 +66,6 @@ public class RNNotificationsPackage implements ReactPackage, AppLifecycleFacade.
 
     @Override
     public void onActivityStarted(Activity activity) {
-        if (InitialNotificationHolder.getInstance().get() == null) {
-            callOnOpenedIfNeed(activity);
-        }
     }
 
     @Override

--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/NotificationIntentAdapter.java
@@ -21,9 +21,7 @@ public class NotificationIntentAdapter {
         } else {
             Intent mainActivityIntent = appContext.getPackageManager().getLaunchIntentForPackage(appContext.getPackageName());
             mainActivityIntent.putExtra(PUSH_NOTIFICATION_EXTRA_NAME, notification.asBundle());
-            TaskStackBuilder taskStackBuilder = TaskStackBuilder.create(appContext);
-            taskStackBuilder.addNextIntentWithParentStack(mainActivityIntent);
-            return taskStackBuilder.getPendingIntent((int) System.currentTimeMillis(), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
+            return PendingIntent.getActivity(appContext, (int) System.currentTimeMillis(), mainActivityIntent, PendingIntent.FLAG_ONE_SHOT | PendingIntent.FLAG_IMMUTABLE);
         }
     }
 


### PR DESCRIPTION
Issue fixed:

- App get relaunch (splash screen) on notification tap while app is in running state.
- Notification handled multiple times.
Steps

   1.  Tap on notification while app is not in running state, it will launch Activity_A.
   2. Navigate to any other activity Activity_B based on notification received.
   3. Press back button and navigate back to Activity_A
   4. App will auto navigate to ActivityB as previous intent still have extras for notification.

- Android 11 device: Notification handled even when app get relaunched from history.

   1.  Tap on notification while app is not in running state.
   2. execute code based on  notification.
   3. Close app by pressing back button
   4. Launch app from history(recent app list).
   5. App will try to process previous notification as activity got launched from history and intent will have notification extras.