### PR TITLE
Update build.gradle

### DIFF
--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -62,9 +62,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    dexOptions {
-        javaMaxHeapSize "4g"
-    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
Fix for warning:

`DSL element 'dexOptions' is obsolete and should be removed.\nIt will be removed in version 8.0 of the Android Gradle plugin.\nUsing it has no effect, and the AndroidGradle plugin optimizes dexing automatically`