### PR TITLE
Wrong response type for registerNotificationReceivedBackground in the Docs

### DIFF
--- a/website/docs/docs/notifications-events.md
+++ b/website/docs/docs/notifications-events.md
@@ -29,11 +29,12 @@ constructor() {
       completion();
 		});
 		
-		Notifications.events().registerNotificationReceivedBackground((notification: Notification, completion: (response: NotificationCompletion) => void) => {
+		Notifications.events().registerNotificationReceivedBackground((notification: Notification, completion: (response: NotificationBackgroundFetchResult) => void) => {
       console.log("Notification Received - Background", notification.payload);
-
-      // Calling completion on iOS with `alert: true` will present the native iOS inApp notification.
-      completion({alert: true, sound: true, badge: false});
+      
+      // completion(NotificationBackgroundFetchResult.NO_DATA);
+      // completion(NotificationBackgroundFetchResult.NEW_DATA);
+      // completion(NotificationBackgroundFetchResult.FAILED);
 		});
 }
 ```


### PR DESCRIPTION
Hey there!

While reading the docs I noticed that the response type of `registerNotificationReceivedBackground` given in the docs was different than the one in the code.

I am not sure what explanations should be added after the change, but if you could help me with that, I'd appreciate that. Thanks!