### PR TITLE
add link to google release notes to get updated versions of gradle pl…

### DIFF
--- a/website/docs/docs/installation-android.md
+++ b/website/docs/docs/installation-android.md
@@ -34,7 +34,7 @@ buildscript {
     ...
     dependencies {
         ...
-        classpath 'com.google.gms:google-services:4.0.0'
+        classpath 'com.google.gms:google-services:x.x.x'
     }
 }
 ```
@@ -45,11 +45,13 @@ buildscript {
 dependencies {
     ...
     implementation project(':react-native-notifications')
-    implementation 'com.google.firebase:firebase-core:16.0.0'
+    implementation 'com.google.firebase:firebase-core:x.x.x'
 }
 
 apply plugin: 'com.google.gms.google-services'
 ```
+
+You can grab version numbers from [Google's Release Notes](https://developers.google.com/android/guides/releases)
 
 #### Step #5: Link react-native-notifications
 


### PR DESCRIPTION
Removed hardcoded versions in Android install docs and added a link to Google's release notes containing versions for their gradle plugins