### PR TITLE
Fix android build for RN 0.72

### DIFF
--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -97,7 +97,7 @@ android {
     testOptions {
         unitTests.all { t ->
             reports {
-                html.enabled true
+                html.required.set true
             }
             testLogging {
                 events "PASSED", "SKIPPED", "FAILED", "standardOut", "standardError"


### PR DESCRIPTION
Fix #975 
https://github.com/wix/react-native-notifications/issues/975

Replace deprecated method setEnabled by required.set()
Use [getRequired()](https://docs.gradle.org/7.3/javadoc/org/gradle/api/reporting/Report.html#getRequired--).set() instead.