### PR TITLE
Handle "FirebaseApp not initialized" exception that crashes apps

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmToken.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/fcm/FcmToken.java
@@ -72,7 +72,21 @@ public class FcmToken implements IFcmToken {
     }
 
     protected void refreshToken() {
-        FirebaseMessaging.getInstance().getToken()
+        FirebaseMessaging instance;
+
+        try {
+            instance = FirebaseMessaging.getInstance();
+        } catch (IllegalStateException e) {
+            // This would be expected when only local notifications are used and Firebase is not configured
+            if (BuildConfig.DEBUG) Log.w(
+                LOGTAG,
+                "FirebaseApp is not initialized. See https://wix.github.io/react-native-notifications/docs/installation-android#receiving-push-notifications",
+                e
+            );
+            return;
+        }
+
+        instance.getToken()
             .addOnCompleteListener(task -> {
                 if (!task.isSuccessful()) {
                     if (BuildConfig.DEBUG) Log.w(LOGTAG, "Fetching FCM registration token failed", task.getException());


### PR DESCRIPTION
## Summary

There is a longstanding bug (4+ years) where users, who are only using the local notifications feature, experience an application crash on initial boot and/or when the refresh token logic runs.

```
12-06 18:52:48.947 11343 11367 E AndroidRuntime: Caused by: java.lang.IllegalStateException: Default FirebaseApp is not initialized in this process com.my_app. Make sure to call FirebaseApp.initializeApp(Context) first.
12-06 18:52:48.947 11343 11367 E AndroidRuntime:        at com.google.firebase.FirebaseApp.getInstance(FirebaseApp.java:183)
12-06 18:52:48.947 11343 11367 E AndroidRuntime:        at com.google.firebase.messaging.FirebaseMessaging.getInstance(com.google.firebase:firebase-messaging@@21.1.0:1)
12-06 18:52:48.947 11343 11367 E AndroidRuntime:        at com.wix.reactnativenotifications.fcm.FcmToken.refreshToken(FcmToken.java:75)
12-06 18:52:48.947 11343 11367 E AndroidRuntime:        at com.wix.reactnativenotifications.fcm.FcmToken.onAppReady(FcmToken.java:65)
12-06 18:52:48.947 11343 11367 E AndroidRuntime:        at com.wix.reactnativenotifications.fcm.FcmInstanceIdRefreshHandlerService.onHandleWork(FcmInstanceIdRefreshHandlerService.java:26)
```

The documentation and API make it appear that Firebase is not required to be configured to use this library.

## Related Issues
- #343 
- #924 
- #285 
- #337

Comments are still being made, [as recent as last month ](https://github.com/wix/react-native-notifications/issues/924#issuecomment-1718809764), commenting on this exact bug.

## Proposed Improvement

Looking at the source code, it seems like the intention was that Firebase failures would be handled and not crash the application.

The source of the issue is that the `FirebaseMessaging.getInstance()` method throws an exception immediately, when not configured, that triggers a runtime crash. I propose catching this error and log a warning with an actionable step that developers can take.

I think fixing this issue would be a _small_ change but a **significant improvement** for many developers and help ensure everyone benefits and succeeds with the hard work that has been put into this project 🙇 

**Edit:** Given what's going on in current world events, this is not an important issue, feel free to ignore. Hope staff at Wix are getting the support they need.

## Temporary Fork

In the interim I've created a temporary package fork that people can take advantage until someday we can resolve this 😊 

https://www.npmjs.com/package/@jamsinclair/react-native-notifications

