### PR TITLE
docs: Fix API Documentation for postLocalNotification date format - IOS

### DIFF
--- a/website/docs/docs/localNotifications.md
+++ b/website/docs/docs/localNotifications.md
@@ -19,7 +19,7 @@ let localNotification = Notifications.postLocalNotification({
 	silent: false,
 	category: "SOME_CATEGORY",
 	userInfo: { },
-	fireDate: new Date(),
+	fireDate: new Date(Date.now() + 10000).toISOString() // isoString
 });
 ```
 
@@ -47,7 +47,7 @@ let someLocalNotification = Notifications.postLocalNotification({
 	sound: "chime.aiff",
 	category: "SOME_CATEGORY",
 	userInfo: { },
-	fireDate: new Date(),
+	fireDate: new Date(Date.now() + 10000).toISOString() // isoString
 });
 
 Notifications.cancelLocalNotification(someLocalNotification);


### PR DESCRIPTION
<!-- Please provide enough information so that others can review your pull request. -->
<!-- Keep pull requests small and focused on a single change. -->

### Motivation
The fireDate requires it to be .toISOString(), new Date() is not sufficient On page https://wix.github.io/react-native-notifications/docs/localNotifications

### Related issue

issue #1010 