### PR TITLE
Removed deprecated method - Android fix

### DIFF
--- a/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
+++ b/lib/android/app/src/main/java/com/wix/reactnativenotifications/core/ReactAppLifecycleFacade.java
@@ -46,12 +46,7 @@ public class ReactAppLifecycleFacade implements AppLifecycleFacade {
         if (mReactContext == null) {
             return false;
         }
-
-        try {
-            return mReactContext.hasActiveCatalystInstance();
-        } catch (Exception e) {
-            return mReactContext.hasActiveReactInstance();
-        }
+         return mReactContext.hasActiveCatalystInstance();  //hasActiveReactInstance method has been deprecated
     }
 
     @Override


### PR DESCRIPTION
Facing an issue while launching android app each time, so have removed the **hasActiveReactInstance** deprecated method from ReactAppLifecycleFacade.java file. 

Version facing issues - 
React Native version : 0.63.3
react-native-notifications : 4.3.3