### PR TITLE
docs: Fix typo in the sample code of API Document

### DIFF
--- a/website/docs/api/general-events.md
+++ b/website/docs/api/general-events.md
@@ -65,7 +65,7 @@ Notifications.events().registerRemoteNotificationsRegistrationFailed((event: Reg
 Fired when the user does not grant permission to receive push notifications. Typically occurs when pressing the "Don't Allow" button in iOS permissions overlay.
 
 ```js
-Notifications.events().registerRemoteNotificationRegistrationDenied(() => {
+Notifications.events().registerRemoteNotificationsRegistrationDenied(() => {
   console.log('Notification permissions not granted')
 })
 ```


### PR DESCRIPTION
I noticed a small typo in the sample code of API documentation and have corrected it.

current: `registerRemoteNotificationRegistrationDenied`
correct: `registerRemoteNotificationsRegistrationDenied` (with an additional 's' after 'Notification').

Thank you for maintaining this useful library!