### PR TITLE
feat: add support to multiple categories

### DIFF
--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -48,15 +48,20 @@
 }
 
 - (void)setCategories:(NSArray *)json {
-    NSMutableSet<UNNotificationCategory *>* categories = nil;
-    
-    if ([json count] > 0) {
-        categories = [NSMutableSet new];
+    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
+
+    [center getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> * _Nonnull existingCategories) {
+        NSMutableSet<UNNotificationCategory *> *updatedCategories = [existingCategories mutableCopy];
+
         for (NSDictionary* categoryJson in json) {
-            [categories addObject:[RCTConvert UNMutableUserNotificationCategory:categoryJson]];
+            UNNotificationCategory *newCategory = [RCTConvert UNMutableUserNotificationCategory:categoryJson];
+            if (newCategory) {
+                [updatedCategories addObject:newCategory];
+            }
         }
-    }
-    [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
+
+        [center setNotificationCategories:updatedCategories];
+    }];
 }
 
 - (void)postLocalNotification:(NSDictionary *)notification withId:(NSNumber *)notificationId {

--- a/lib/ios/RNNotificationCenter.m
+++ b/lib/ios/RNNotificationCenter.m
@@ -48,20 +48,16 @@
 }
 
 - (void)setCategories:(NSArray *)json {
-    UNUserNotificationCenter *center = [UNUserNotificationCenter currentNotificationCenter];
-
-    [center getNotificationCategoriesWithCompletionHandler:^(NSSet<UNNotificationCategory *> * _Nonnull existingCategories) {
-        NSMutableSet<UNNotificationCategory *> *updatedCategories = [existingCategories mutableCopy];
-
-        for (NSDictionary* categoryJson in json) {
-            UNNotificationCategory *newCategory = [RCTConvert UNMutableUserNotificationCategory:categoryJson];
-            if (newCategory) {
-                [updatedCategories addObject:newCategory];
-            }
+    NSMutableSet<UNNotificationCategory *>* categories = [NSMutableSet new];
+    
+    for (NSDictionary* categoryJson in json) {
+        UNNotificationCategory *category = [RCTConvert UNMutableUserNotificationCategory:categoryJson];
+        if (category) {
+            [categories addObject:category];
         }
+    }
 
-        [center setNotificationCategories:updatedCategories];
-    }];
+    [[UNUserNotificationCenter currentNotificationCenter] setNotificationCategories:categories];
 }
 
 - (void)postLocalNotification:(NSDictionary *)notification withId:(NSNumber *)notificationId {

--- a/lib/src/Notifications.ts
+++ b/lib/src/Notifications.ts
@@ -69,7 +69,7 @@ export class NotificationsRoot {
   /**
    * setCategories
    */
-  public setCategories(categories: [NotificationCategory?]) {
+  public setCategories(categories: NotificationCategory[]) {
     this.commands.setCategories(categories);
   }
 

--- a/lib/src/adapters/NativeCommandsSender.ts
+++ b/lib/src/adapters/NativeCommandsSender.ts
@@ -22,7 +22,7 @@ interface NativeCommandsModule {
   removeDeliveredNotifications(identifiers: Array<string>): void;
   removeAllDeliveredNotifications(): void;
   getDeliveredNotifications(): Promise<Notification[]>;
-  setCategories(categories: [NotificationCategory?]): void;
+  setCategories(categories: NotificationCategory[]): void;
   finishPresentingNotification(notificationId: string, callback: NotificationCompletion): void;
   finishHandlingAction(notificationId: string): void;
   setNotificationChannel(notificationChannel: NotificationChannel): void;
@@ -59,7 +59,7 @@ export class NativeCommandsSender {
     return this.nativeCommandsModule.registerPushKit();
   }
 
-  setCategories(categories: [NotificationCategory?]) {
+  setCategories(categories: NotificationCategory[]) {
     this.nativeCommandsModule.setCategories(categories);
   }
 

--- a/lib/src/commands/Commands.ts
+++ b/lib/src/commands/Commands.ts
@@ -44,7 +44,7 @@ export class Commands {
     this.nativeCommandsSender.registerPushKit();
   }
 
-  public setCategories(categories: [NotificationCategory?]) {
+  public setCategories(categories: NotificationCategory[]) {
     this.nativeCommandsSender.setCategories(categories);
   }
 


### PR DESCRIPTION
Currently, when setting a category, the lib overrides the previous categories because it does not load the previous notification center.
There are some open issues with this question, and it is not clear in the doc that this overlap exists.

resolve: #573