### PR TITLE
Update package.json for correct link on npm website

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "type": "git",
     "url": "https://github.com/wix/react-native-notifications.git"
   },
-  "homepage": "https://github.com/wix/react-native-notifications",
+  "homepage": "https://wix.github.io/react-native-notifications/docs/getting-started",
   "bugs": {
     "url": "https://github.com/wix/react-native-notifications/issues"
   },


### PR DESCRIPTION
On this page - https://www.npmjs.com/package/react-native-notifications, the Homepage link takes you to the git repo.

Instead it should go to the Homepage of React Native Notification.