### PR TITLE
Update build.gradle

### DIFF
--- a/lib/android/app/build.gradle
+++ b/lib/android/app/build.gradle
@@ -62,9 +62,6 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    dexOptions {
-        javaMaxHeapSize "4g"
-    }
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
I am getting the following message in my build output.

[05:52:59]: ▸ > Configure project :reactnativenotifications
[05:52:59]: ▸ WARNING: DSL element 'dexOptions' is obsolete and should be removed.
[05:52:59]: ▸ It will be removed in version 8.0 of the Android Gradle plugin.
[05:52:59]: ▸ Using it has no effect, and the AndroidGradle plugin optimizes dexing automatically.