### PR TITLE
package.json: Mark lodash as a runtime dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,11 +48,14 @@
     "react": "*",
     "react-native": "*"
   },
+  "dependencies": {
+    "@types/lodash": "4.14.182",
+    "lodash": "4.17.21",
+  }
   "devDependencies": {
     "@babel/plugin-proposal-export-default-from": "7.2.0",
     "@babel/plugin-proposal-export-namespace-from": "7.2.0",
     "@types/jest": "^27.0.0",
-    "@types/lodash": "4.14.182",
     "@types/react": "^17.0.0",
     "@types/react-native": "0.67.6",
     "@types/react-test-renderer": "16.9.2",
@@ -60,7 +63,6 @@
     "detox": "^19.4.2",
     "github-release-notes": "https://github.com/yogevbd/github-release-notes/tarball/e601b3dba72dcd6cba323c1286ea6dd0c0110b58",
     "jest": "^27.0.0",
-    "lodash": "4.17.21",
     "metro-babel-register": "^0.73.2",
     "metro-react-native-babel-preset": "^0.67.0",
     "react": "^17.0.0",


### PR DESCRIPTION
Should fix https://github.com/wix/react-native-notifications/issues/1065